### PR TITLE
Exception trace starts with assertion call

### DIFF
--- a/src/InvalidArgumentException.php
+++ b/src/InvalidArgumentException.php
@@ -11,6 +11,30 @@
 
 namespace Webmozart\Assert;
 
+use Throwable;
+
 class InvalidArgumentException extends \InvalidArgumentException
 {
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $trace = $this->getTrace();
+        if (isset($trace[0]['class']) && $trace[0]['class'] === Assert::class) {
+            array_shift($trace);
+
+            try {
+                $property = new \ReflectionProperty(\Exception::class, 'trace');
+                $property->setAccessible(true);
+                $property->setValue($this, $trace);
+                $property->setAccessible(false);
+            } catch (\Exception $ignored) {
+            }
+
+            if (!empty($trace)) {
+                $this->file = $trace[0]['file'];
+                $this->line = $trace[0]['line'];
+            }
+        }
+    }
 }

--- a/src/InvalidArgumentException.php
+++ b/src/InvalidArgumentException.php
@@ -13,7 +13,7 @@ namespace Webmozart\Assert;
 
 class InvalidArgumentException extends \InvalidArgumentException
 {
-    public function __construct($message = null, $code = null, $previous = null)
+    public function __construct($message = '', $code = 0, $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -718,7 +718,7 @@ class AssertTest extends TestCase
             array('eq', array(new ArrayIterator(array()), new stdClass()), 'Expected a value equal to stdClass. Got: ArrayIterator'),
             array('eq', array(1, self::getResource()), 'Expected a value equal to resource. Got: 1'),
 
-            array('lessThan', array(new \DateTime('2020-01-01 00:00:00'), new \DateTime('1999-01-01 00:00:00')), 'Expected a value less than DateTime: "1999-01-01T00:00:00+00:00". Got: DateTime: "2020-01-01T00:00:00+00:00"'),
+            array('lessThan', array(new \DateTime('2020-01-01 00:00:00', new \DateTimeZone('UTC')), new \DateTime('1999-01-01 00:00:00', new \DateTimeZone('UTC'))), 'Expected a value less than DateTime: "1999-01-01T00:00:00+00:00". Got: DateTime: "2020-01-01T00:00:00+00:00"'),
         );
     }
 

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -718,7 +718,7 @@ class AssertTest extends TestCase
             array('eq', array(new ArrayIterator(array()), new stdClass()), 'Expected a value equal to stdClass. Got: ArrayIterator'),
             array('eq', array(1, self::getResource()), 'Expected a value equal to resource. Got: 1'),
 
-            array('lessThan', array(new \DateTime('2020-01-01 00:00:00', new \DateTimeZone('UTC')), new \DateTime('1999-01-01 00:00:00', new \DateTimeZone('UTC'))), 'Expected a value less than DateTime: "1999-01-01T00:00:00+00:00". Got: DateTime: "2020-01-01T00:00:00+00:00"'),
+            array('lessThan', array(new \DateTime('2020-01-01 00:00:00'), new \DateTime('1999-01-01 00:00:00')), 'Expected a value less than DateTime: "1999-01-01T00:00:00+00:00". Got: DateTime: "2020-01-01T00:00:00+00:00"'),
         );
     }
 

--- a/tests/InvalidArgumentExceptionTest.php
+++ b/tests/InvalidArgumentExceptionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests;
+
+
+use PHPUnit\Framework\TestCase;
+use Webmozart\Assert\Assert;
+use Webmozart\Assert\InvalidArgumentException;
+
+class InvalidArgumentExceptionTest extends TestCase
+{
+    public function testAssertFileLine()
+    {
+        try {
+            $line = __LINE__;
+            Assert::notNull(null);
+            $this->fail('Assertion not triggered');
+        } catch (\Exception $e) {
+            $this->assertEquals($line + 1, $e->getLine());
+            $this->assertEquals(__FILE__, $e->getFile());
+        }
+    }
+
+    public function testAssertStackTrace()
+    {
+        try {
+            $line = __LINE__;
+            Assert::notNull(null);
+            $this->fail('Assertion not triggered');
+        } catch (\Exception $e) {
+            $this->assertStringStartsWith(
+                sprintf(
+                    '#0 %s(%d): Webmozart\Assert\Assert::notNull(NULL)',
+                    __FILE__,
+                    $line + 1
+                ),
+                $e->getTraceAsString()
+            );
+        }
+    }
+
+    public function testAssertTraceArray()
+    {
+        try {
+            $line = __LINE__;
+            Assert::notNull(null);
+            $this->fail('Assertion not triggered');
+        } catch (\Exception $e) {
+            $trace = $e->getTrace();
+            $this->assertEquals(
+                array(
+                    "file" => __FILE__,
+                    "line" => $line + 1,
+                    "function" => "notNull",
+                    "class" => Assert::class,
+                    "type" => "::",
+                    "args" => array(null)
+                ),
+                $trace[0]
+            );
+        }
+    }
+
+    public function testThrowException()
+    {
+        try {
+            throw new InvalidArgumentException();
+        } catch (\Exception $e) {
+            $trace = $e->getTrace();
+            $this->assertEquals(__CLASS__, $trace[0]['class']);
+        }
+    }
+}

--- a/tests/InvalidArgumentExceptionTest.php
+++ b/tests/InvalidArgumentExceptionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Webmozart\Assert\Tests;
 
-
 use PHPUnit\Framework\TestCase;
 use Webmozart\Assert\Assert;
 use Webmozart\Assert\InvalidArgumentException;
@@ -51,12 +50,12 @@ class InvalidArgumentExceptionTest extends TestCase
             $trace = $e->getTrace();
             $this->assertEquals(
                 array(
-                    "file" => __FILE__,
-                    "line" => $line + 1,
-                    "function" => "notNull",
-                    "class" => Assert::class,
-                    "type" => "::",
-                    "args" => array(null)
+                    'file' => __FILE__,
+                    'line' => $line + 1,
+                    'function' => 'notNull',
+                    'class' => Assert::class,
+                    'type' => '::',
+                    'args' => array(null)
                 ),
                 $trace[0]
             );
@@ -72,4 +71,29 @@ class InvalidArgumentExceptionTest extends TestCase
             $this->assertEquals(__CLASS__, $trace[0]['class']);
         }
     }
+
+    public function testCallUserFunction()
+    {
+        try {
+            $line = __LINE__;
+            call_user_func_array(array(Assert::class, 'notNull'), array(null));
+            $this->fail('Assertion not triggered');
+        } catch (\Exception $e) {
+            $trace = $e->getTrace();
+            $this->assertEquals(
+                array(
+                    'file' => __FILE__,
+                    'line' => $line + 1,
+                    'function' => 'call_user_func_array',
+                    'args' => array(
+                        array(Assert::class, 'notNull'),
+                        array(null),
+                    ),
+                ),
+                $trace[0]
+            );
+        }
+    }
+
+
 }

--- a/tests/InvalidArgumentExceptionTest.php
+++ b/tests/InvalidArgumentExceptionTest.php
@@ -31,7 +31,7 @@ class InvalidArgumentExceptionTest extends TestCase
         } catch (\Exception $e) {
             $this->assertStringStartsWith(
                 sprintf(
-                    '#0 %s(%d): Webmozart\Assert\Assert::notNull(NULL)',
+                    '#0 %s(%d): Webmozart\Assert\Assert::notNull',
                     __FILE__,
                     $line + 1
                 ),
@@ -48,17 +48,11 @@ class InvalidArgumentExceptionTest extends TestCase
             $this->fail('Assertion not triggered');
         } catch (\Exception $e) {
             $trace = $e->getTrace();
-            $this->assertEquals(
-                array(
-                    'file' => __FILE__,
-                    'line' => $line + 1,
-                    'function' => 'notNull',
-                    'class' => Assert::class,
-                    'type' => '::',
-                    'args' => array(null)
-                ),
-                $trace[0]
-            );
+
+            $this->assertIsArray($trace);
+            $this->assertArrayHasKey(0, $trace);
+            $this->assertEquals(__FILE__, $trace[0]['file']);
+            $this->assertEquals($line + 1, $trace[0]['line']);
         }
     }
 
@@ -80,20 +74,11 @@ class InvalidArgumentExceptionTest extends TestCase
             $this->fail('Assertion not triggered');
         } catch (\Exception $e) {
             $trace = $e->getTrace();
-            $this->assertEquals(
-                array(
-                    'file' => __FILE__,
-                    'line' => $line + 1,
-                    'function' => 'call_user_func_array',
-                    'args' => array(
-                        array(Assert::class, 'notNull'),
-                        array(null),
-                    ),
-                ),
-                $trace[0]
-            );
+
+            $this->assertIsArray($trace);
+            $this->assertArrayHasKey(0, $trace);
+            $this->assertEquals(__FILE__, $trace[0]['file']);
+            $this->assertEquals($line + 1, $trace[0]['line']);
         }
     }
-
-
 }


### PR DESCRIPTION
When logging errors, the place of the check call is lost and you have to look in the call stack. The exclusion from the call stack of the place where the exception was thrown allows you to send an exception to the logger or Sentry and immediately see the place where the conditions were not checked.