### PR TITLE
Mixin: avoid __callStatic calls

### DIFF
--- a/bin/src/MixinGenerator.php
+++ b/bin/src/MixinGenerator.php
@@ -99,8 +99,6 @@ PHP
 /**
  * This trait provides nurllOr* and all* variants of assertion base methods.
  * Do not use this trait directly: it will change, and is not designed for reuse.
- *
- * @internal
  */
 trait Mixin
 {

--- a/bin/src/MixinGenerator.php
+++ b/bin/src/MixinGenerator.php
@@ -53,10 +53,6 @@ final class MixinGenerator
             <<<'PHP'
 <?php
 
-/**
- * provides type inference and auto-completion for magic static methods of Assert.
- */
-
 %s
 PHP
             ,
@@ -101,8 +97,10 @@ PHP
         return \sprintf(
             <<<'PHP'
 /**
- * This trait aids static analysis tooling in introspecting assertion magic methods.
+ * This trait provides nurllOr* and all* variants of assertion base methods.
  * Do not use this trait directly: it will change, and is not designed for reuse.
+ *
+ * @internal
  */
 trait Mixin
 {
@@ -125,7 +123,9 @@ PHP
      */
     private function nullOr(ReflectionMethod $method, int $indent): ?string
     {
-        return $this->assertion($method, 'nullOr%s', '%s|null', $indent);
+        return $this->assertion($method, 'nullOr%s', '%s|null', $indent, function (string $firstParameter, string $parameters) use ($method) {
+            return "null === {$firstParameter} || static::{$method->name}({$firstParameter}, {$parameters});";
+        });
     }
 
     /**
@@ -138,20 +138,31 @@ PHP
      */
     private function all(ReflectionMethod $method, int $indent): ?string
     {
-        return $this->assertion($method, 'all%s', 'iterable<%s>', $indent);
+        return $this->assertion($method, 'all%s', 'iterable<%s>', $indent, function (string $firstParameter, string $parameters) use ($method) {
+            return <<<BODY
+static::isIterable({$firstParameter});
+
+foreach ({$firstParameter} as \$entry) {
+    static::{$method->name}(\$entry, {$parameters});
+}
+BODY;
+        });
     }
 
     /**
+     * @psalm-param callable(string,string):string $body
+     *
      * @param ReflectionMethod $method
      * @param string           $methodNameTemplate
      * @param string           $typeTemplate
      * @param int              $indent
+     * @param callable         $body
      *
      * @return string|null
      *
      * @throws ReflectionException
      */
-    private function assertion(ReflectionMethod $method, string $methodNameTemplate, string $typeTemplate, int $indent): ?string
+    private function assertion(ReflectionMethod $method, string $methodNameTemplate, string $typeTemplate, int $indent, callable $body): ?string
     {
         $newMethodName = sprintf($methodNameTemplate, ucfirst($method->name));
 
@@ -258,7 +269,7 @@ PHP
             $phpdocLinesDeduplicatedEmptyLines[] = $line;
         }
 
-        return $this->staticMethod($newMethodName, $parameters, $parametersDefaults, $phpdocLinesDeduplicatedEmptyLines, $indent);
+        return $this->staticMethod($newMethodName, $parameters, $parametersDefaults, $phpdocLinesDeduplicatedEmptyLines, $indent, $body);
     }
 
     private function applyTypeTemplate(string $type, string $typeTemplate): string
@@ -318,29 +329,32 @@ PHP
      * @psalm-param list<string> $parameters
      * @psalm-param array<string, scalar|null> $defaultValues
      * @psalm-param list<string> $phpdocLines
+     * @psalm-param callable(string,string):string $body
      *
      * @param string   $name
      * @param string[] $parameters
      * @param string[] $defaultValues
      * @param array    $phpdocLines
      * @param int      $indent
+     * @param callable $body
      *
      * @return string
      */
-    private function staticMethod(string $name, array $parameters, array $defaultValues, array $phpdocLines, int $indent): string
+    private function staticMethod(string $name, array $parameters, array $defaultValues, array $phpdocLines, int $indent, callable $body): string
     {
         $indentation = str_repeat(' ', $indent);
 
         $staticFunction = $this->phpdoc($phpdocLines, $indent)."\n";
         $staticFunction .= $indentation.'public static function '.$name.$this->functionParameters($parameters, $defaultValues)."\n"
-            .$indentation."{\n"
-            .$indentation.$indentation.'static::__callStatic('
-            .'\'' . $name . '\', array('
-            .implode(', ', \array_map(static function (string $parameter): string {
-                return '$'. $parameter;
-            }, $parameters))
-            ."));\n"
-            .$indentation.'}';
+            .$indentation."{\n";
+
+        $firstParameter = '$'.array_shift($parameters);
+        $parameters = implode(', ', \array_map(static function (string $parameter): string {
+            return '$'.$parameter;
+        }, $parameters));
+
+        $staticFunction .= preg_replace('/(?<=^|\n)(?!\n)/', $indentation.$indentation, $body($firstParameter, $parameters))."\n";
+        $staticFunction .= $indentation.'}';
 
         return $staticFunction;
     }

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * provides type inference and auto-completion for magic static methods of Assert.
- */
-
 namespace Webmozart\Assert;
 
 use ArrayAccess;
@@ -12,8 +8,10 @@ use Countable;
 use Throwable;
 
 /**
- * This trait aids static analysis tooling in introspecting assertion magic methods.
+ * This trait provides nurllOr* and all* variants of assertion base methods.
  * Do not use this trait directly: it will change, and is not designed for reuse.
+ *
+ * @internal
  */
 trait Mixin
 {
@@ -30,7 +28,7 @@ trait Mixin
      */
     public static function nullOrString($value, $message = '')
     {
-        static::__callStatic('nullOrString', array($value, $message));
+        null === $value || static::string($value, $message);
     }
 
     /**
@@ -46,7 +44,11 @@ trait Mixin
      */
     public static function allString($value, $message = '')
     {
-        static::__callStatic('allString', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::string($entry, $message);
+        }
     }
 
     /**
@@ -62,7 +64,7 @@ trait Mixin
      */
     public static function nullOrStringNotEmpty($value, $message = '')
     {
-        static::__callStatic('nullOrStringNotEmpty', array($value, $message));
+        null === $value || static::stringNotEmpty($value, $message);
     }
 
     /**
@@ -78,7 +80,11 @@ trait Mixin
      */
     public static function allStringNotEmpty($value, $message = '')
     {
-        static::__callStatic('allStringNotEmpty', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::stringNotEmpty($entry, $message);
+        }
     }
 
     /**
@@ -94,7 +100,7 @@ trait Mixin
      */
     public static function nullOrInteger($value, $message = '')
     {
-        static::__callStatic('nullOrInteger', array($value, $message));
+        null === $value || static::integer($value, $message);
     }
 
     /**
@@ -110,7 +116,11 @@ trait Mixin
      */
     public static function allInteger($value, $message = '')
     {
-        static::__callStatic('allInteger', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::integer($entry, $message);
+        }
     }
 
     /**
@@ -126,7 +136,7 @@ trait Mixin
      */
     public static function nullOrIntegerish($value, $message = '')
     {
-        static::__callStatic('nullOrIntegerish', array($value, $message));
+        null === $value || static::integerish($value, $message);
     }
 
     /**
@@ -142,7 +152,11 @@ trait Mixin
      */
     public static function allIntegerish($value, $message = '')
     {
-        static::__callStatic('allIntegerish', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::integerish($entry, $message);
+        }
     }
 
     /**
@@ -158,7 +172,7 @@ trait Mixin
      */
     public static function nullOrPositiveInteger($value, $message = '')
     {
-        static::__callStatic('nullOrPositiveInteger', array($value, $message));
+        null === $value || static::positiveInteger($value, $message);
     }
 
     /**
@@ -174,7 +188,11 @@ trait Mixin
      */
     public static function allPositiveInteger($value, $message = '')
     {
-        static::__callStatic('allPositiveInteger', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::positiveInteger($entry, $message);
+        }
     }
 
     /**
@@ -190,7 +208,7 @@ trait Mixin
      */
     public static function nullOrFloat($value, $message = '')
     {
-        static::__callStatic('nullOrFloat', array($value, $message));
+        null === $value || static::float($value, $message);
     }
 
     /**
@@ -206,7 +224,11 @@ trait Mixin
      */
     public static function allFloat($value, $message = '')
     {
-        static::__callStatic('allFloat', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::float($entry, $message);
+        }
     }
 
     /**
@@ -222,7 +244,7 @@ trait Mixin
      */
     public static function nullOrNumeric($value, $message = '')
     {
-        static::__callStatic('nullOrNumeric', array($value, $message));
+        null === $value || static::numeric($value, $message);
     }
 
     /**
@@ -238,7 +260,11 @@ trait Mixin
      */
     public static function allNumeric($value, $message = '')
     {
-        static::__callStatic('allNumeric', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::numeric($entry, $message);
+        }
     }
 
     /**
@@ -254,7 +280,7 @@ trait Mixin
      */
     public static function nullOrNatural($value, $message = '')
     {
-        static::__callStatic('nullOrNatural', array($value, $message));
+        null === $value || static::natural($value, $message);
     }
 
     /**
@@ -270,7 +296,11 @@ trait Mixin
      */
     public static function allNatural($value, $message = '')
     {
-        static::__callStatic('allNatural', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::natural($entry, $message);
+        }
     }
 
     /**
@@ -286,7 +316,7 @@ trait Mixin
      */
     public static function nullOrBoolean($value, $message = '')
     {
-        static::__callStatic('nullOrBoolean', array($value, $message));
+        null === $value || static::boolean($value, $message);
     }
 
     /**
@@ -302,7 +332,11 @@ trait Mixin
      */
     public static function allBoolean($value, $message = '')
     {
-        static::__callStatic('allBoolean', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::boolean($entry, $message);
+        }
     }
 
     /**
@@ -318,7 +352,7 @@ trait Mixin
      */
     public static function nullOrScalar($value, $message = '')
     {
-        static::__callStatic('nullOrScalar', array($value, $message));
+        null === $value || static::scalar($value, $message);
     }
 
     /**
@@ -334,7 +368,11 @@ trait Mixin
      */
     public static function allScalar($value, $message = '')
     {
-        static::__callStatic('allScalar', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::scalar($entry, $message);
+        }
     }
 
     /**
@@ -350,7 +388,7 @@ trait Mixin
      */
     public static function nullOrObject($value, $message = '')
     {
-        static::__callStatic('nullOrObject', array($value, $message));
+        null === $value || static::object($value, $message);
     }
 
     /**
@@ -366,7 +404,11 @@ trait Mixin
      */
     public static function allObject($value, $message = '')
     {
-        static::__callStatic('allObject', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::object($entry, $message);
+        }
     }
 
     /**
@@ -383,7 +425,7 @@ trait Mixin
      */
     public static function nullOrResource($value, $type = null, $message = '')
     {
-        static::__callStatic('nullOrResource', array($value, $type, $message));
+        null === $value || static::resource($value, $type, $message);
     }
 
     /**
@@ -400,7 +442,11 @@ trait Mixin
      */
     public static function allResource($value, $type = null, $message = '')
     {
-        static::__callStatic('allResource', array($value, $type, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::resource($entry, $type, $message);
+        }
     }
 
     /**
@@ -416,7 +462,7 @@ trait Mixin
      */
     public static function nullOrIsCallable($value, $message = '')
     {
-        static::__callStatic('nullOrIsCallable', array($value, $message));
+        null === $value || static::isCallable($value, $message);
     }
 
     /**
@@ -432,7 +478,11 @@ trait Mixin
      */
     public static function allIsCallable($value, $message = '')
     {
-        static::__callStatic('allIsCallable', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isCallable($entry, $message);
+        }
     }
 
     /**
@@ -448,7 +498,7 @@ trait Mixin
      */
     public static function nullOrIsArray($value, $message = '')
     {
-        static::__callStatic('nullOrIsArray', array($value, $message));
+        null === $value || static::isArray($value, $message);
     }
 
     /**
@@ -464,7 +514,11 @@ trait Mixin
      */
     public static function allIsArray($value, $message = '')
     {
-        static::__callStatic('allIsArray', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isArray($entry, $message);
+        }
     }
 
     /**
@@ -482,7 +536,7 @@ trait Mixin
      */
     public static function nullOrIsTraversable($value, $message = '')
     {
-        static::__callStatic('nullOrIsTraversable', array($value, $message));
+        null === $value || static::isTraversable($value, $message);
     }
 
     /**
@@ -500,7 +554,11 @@ trait Mixin
      */
     public static function allIsTraversable($value, $message = '')
     {
-        static::__callStatic('allIsTraversable', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isTraversable($entry, $message);
+        }
     }
 
     /**
@@ -516,7 +574,7 @@ trait Mixin
      */
     public static function nullOrIsArrayAccessible($value, $message = '')
     {
-        static::__callStatic('nullOrIsArrayAccessible', array($value, $message));
+        null === $value || static::isArrayAccessible($value, $message);
     }
 
     /**
@@ -532,7 +590,11 @@ trait Mixin
      */
     public static function allIsArrayAccessible($value, $message = '')
     {
-        static::__callStatic('allIsArrayAccessible', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isArrayAccessible($entry, $message);
+        }
     }
 
     /**
@@ -548,7 +610,7 @@ trait Mixin
      */
     public static function nullOrIsCountable($value, $message = '')
     {
-        static::__callStatic('nullOrIsCountable', array($value, $message));
+        null === $value || static::isCountable($value, $message);
     }
 
     /**
@@ -564,7 +626,11 @@ trait Mixin
      */
     public static function allIsCountable($value, $message = '')
     {
-        static::__callStatic('allIsCountable', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isCountable($entry, $message);
+        }
     }
 
     /**
@@ -580,7 +646,7 @@ trait Mixin
      */
     public static function nullOrIsIterable($value, $message = '')
     {
-        static::__callStatic('nullOrIsIterable', array($value, $message));
+        null === $value || static::isIterable($value, $message);
     }
 
     /**
@@ -596,7 +662,11 @@ trait Mixin
      */
     public static function allIsIterable($value, $message = '')
     {
-        static::__callStatic('allIsIterable', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isIterable($entry, $message);
+        }
     }
 
     /**
@@ -615,7 +685,7 @@ trait Mixin
      */
     public static function nullOrIsInstanceOf($value, $class, $message = '')
     {
-        static::__callStatic('nullOrIsInstanceOf', array($value, $class, $message));
+        null === $value || static::isInstanceOf($value, $class, $message);
     }
 
     /**
@@ -634,7 +704,11 @@ trait Mixin
      */
     public static function allIsInstanceOf($value, $class, $message = '')
     {
-        static::__callStatic('allIsInstanceOf', array($value, $class, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isInstanceOf($entry, $class, $message);
+        }
     }
 
     /**
@@ -652,7 +726,7 @@ trait Mixin
      */
     public static function nullOrNotInstanceOf($value, $class, $message = '')
     {
-        static::__callStatic('nullOrNotInstanceOf', array($value, $class, $message));
+        null === $value || static::notInstanceOf($value, $class, $message);
     }
 
     /**
@@ -670,7 +744,11 @@ trait Mixin
      */
     public static function allNotInstanceOf($value, $class, $message = '')
     {
-        static::__callStatic('allNotInstanceOf', array($value, $class, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::notInstanceOf($entry, $class, $message);
+        }
     }
 
     /**
@@ -687,7 +765,7 @@ trait Mixin
      */
     public static function nullOrIsInstanceOfAny($value, $classes, $message = '')
     {
-        static::__callStatic('nullOrIsInstanceOfAny', array($value, $classes, $message));
+        null === $value || static::isInstanceOfAny($value, $classes, $message);
     }
 
     /**
@@ -704,7 +782,11 @@ trait Mixin
      */
     public static function allIsInstanceOfAny($value, $classes, $message = '')
     {
-        static::__callStatic('allIsInstanceOfAny', array($value, $classes, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isInstanceOfAny($entry, $classes, $message);
+        }
     }
 
     /**
@@ -723,7 +805,7 @@ trait Mixin
      */
     public static function nullOrIsAOf($value, $class, $message = '')
     {
-        static::__callStatic('nullOrIsAOf', array($value, $class, $message));
+        null === $value || static::isAOf($value, $class, $message);
     }
 
     /**
@@ -742,7 +824,11 @@ trait Mixin
      */
     public static function allIsAOf($value, $class, $message = '')
     {
-        static::__callStatic('allIsAOf', array($value, $class, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isAOf($entry, $class, $message);
+        }
     }
 
     /**
@@ -760,7 +846,7 @@ trait Mixin
      */
     public static function nullOrIsNotA($value, $class, $message = '')
     {
-        static::__callStatic('nullOrIsNotA', array($value, $class, $message));
+        null === $value || static::isNotA($value, $class, $message);
     }
 
     /**
@@ -778,7 +864,11 @@ trait Mixin
      */
     public static function allIsNotA($value, $class, $message = '')
     {
-        static::__callStatic('allIsNotA', array($value, $class, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isNotA($entry, $class, $message);
+        }
     }
 
     /**
@@ -795,7 +885,7 @@ trait Mixin
      */
     public static function nullOrIsAnyOf($value, $classes, $message = '')
     {
-        static::__callStatic('nullOrIsAnyOf', array($value, $classes, $message));
+        null === $value || static::isAnyOf($value, $classes, $message);
     }
 
     /**
@@ -812,7 +902,11 @@ trait Mixin
      */
     public static function allIsAnyOf($value, $classes, $message = '')
     {
-        static::__callStatic('allIsAnyOf', array($value, $classes, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isAnyOf($entry, $classes, $message);
+        }
     }
 
     /**
@@ -828,7 +922,7 @@ trait Mixin
      */
     public static function nullOrIsEmpty($value, $message = '')
     {
-        static::__callStatic('nullOrIsEmpty', array($value, $message));
+        null === $value || static::isEmpty($value, $message);
     }
 
     /**
@@ -844,7 +938,11 @@ trait Mixin
      */
     public static function allIsEmpty($value, $message = '')
     {
-        static::__callStatic('allIsEmpty', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::isEmpty($entry, $message);
+        }
     }
 
     /**
@@ -859,7 +957,7 @@ trait Mixin
      */
     public static function nullOrNotEmpty($value, $message = '')
     {
-        static::__callStatic('nullOrNotEmpty', array($value, $message));
+        null === $value || static::notEmpty($value, $message);
     }
 
     /**
@@ -874,7 +972,11 @@ trait Mixin
      */
     public static function allNotEmpty($value, $message = '')
     {
-        static::__callStatic('allNotEmpty', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::notEmpty($entry, $message);
+        }
     }
 
     /**
@@ -890,7 +992,11 @@ trait Mixin
      */
     public static function allNull($value, $message = '')
     {
-        static::__callStatic('allNull', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::null($entry, $message);
+        }
     }
 
     /**
@@ -905,7 +1011,11 @@ trait Mixin
      */
     public static function allNotNull($value, $message = '')
     {
-        static::__callStatic('allNotNull', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::notNull($entry, $message);
+        }
     }
 
     /**
@@ -921,7 +1031,7 @@ trait Mixin
      */
     public static function nullOrTrue($value, $message = '')
     {
-        static::__callStatic('nullOrTrue', array($value, $message));
+        null === $value || static::true($value, $message);
     }
 
     /**
@@ -937,7 +1047,11 @@ trait Mixin
      */
     public static function allTrue($value, $message = '')
     {
-        static::__callStatic('allTrue', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::true($entry, $message);
+        }
     }
 
     /**
@@ -953,7 +1067,7 @@ trait Mixin
      */
     public static function nullOrFalse($value, $message = '')
     {
-        static::__callStatic('nullOrFalse', array($value, $message));
+        null === $value || static::false($value, $message);
     }
 
     /**
@@ -969,7 +1083,11 @@ trait Mixin
      */
     public static function allFalse($value, $message = '')
     {
-        static::__callStatic('allFalse', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::false($entry, $message);
+        }
     }
 
     /**
@@ -984,7 +1102,7 @@ trait Mixin
      */
     public static function nullOrNotFalse($value, $message = '')
     {
-        static::__callStatic('nullOrNotFalse', array($value, $message));
+        null === $value || static::notFalse($value, $message);
     }
 
     /**
@@ -999,7 +1117,11 @@ trait Mixin
      */
     public static function allNotFalse($value, $message = '')
     {
-        static::__callStatic('allNotFalse', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::notFalse($entry, $message);
+        }
     }
 
     /**
@@ -1012,7 +1134,7 @@ trait Mixin
      */
     public static function nullOrIp($value, $message = '')
     {
-        static::__callStatic('nullOrIp', array($value, $message));
+        null === $value || static::ip($value, $message);
     }
 
     /**
@@ -1025,7 +1147,11 @@ trait Mixin
      */
     public static function allIp($value, $message = '')
     {
-        static::__callStatic('allIp', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::ip($entry, $message);
+        }
     }
 
     /**
@@ -1038,7 +1164,7 @@ trait Mixin
      */
     public static function nullOrIpv4($value, $message = '')
     {
-        static::__callStatic('nullOrIpv4', array($value, $message));
+        null === $value || static::ipv4($value, $message);
     }
 
     /**
@@ -1051,7 +1177,11 @@ trait Mixin
      */
     public static function allIpv4($value, $message = '')
     {
-        static::__callStatic('allIpv4', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::ipv4($entry, $message);
+        }
     }
 
     /**
@@ -1064,7 +1194,7 @@ trait Mixin
      */
     public static function nullOrIpv6($value, $message = '')
     {
-        static::__callStatic('nullOrIpv6', array($value, $message));
+        null === $value || static::ipv6($value, $message);
     }
 
     /**
@@ -1077,7 +1207,11 @@ trait Mixin
      */
     public static function allIpv6($value, $message = '')
     {
-        static::__callStatic('allIpv6', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::ipv6($entry, $message);
+        }
     }
 
     /**
@@ -1090,7 +1224,7 @@ trait Mixin
      */
     public static function nullOrEmail($value, $message = '')
     {
-        static::__callStatic('nullOrEmail', array($value, $message));
+        null === $value || static::email($value, $message);
     }
 
     /**
@@ -1103,7 +1237,11 @@ trait Mixin
      */
     public static function allEmail($value, $message = '')
     {
-        static::__callStatic('allEmail', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::email($entry, $message);
+        }
     }
 
     /**
@@ -1116,7 +1254,7 @@ trait Mixin
      */
     public static function nullOrUniqueValues($values, $message = '')
     {
-        static::__callStatic('nullOrUniqueValues', array($values, $message));
+        null === $values || static::uniqueValues($values, $message);
     }
 
     /**
@@ -1129,7 +1267,11 @@ trait Mixin
      */
     public static function allUniqueValues($values, $message = '')
     {
-        static::__callStatic('allUniqueValues', array($values, $message));
+        static::isIterable($values);
+
+        foreach ($values as $entry) {
+            static::uniqueValues($entry, $message);
+        }
     }
 
     /**
@@ -1143,7 +1285,7 @@ trait Mixin
      */
     public static function nullOrEq($value, $expect, $message = '')
     {
-        static::__callStatic('nullOrEq', array($value, $expect, $message));
+        null === $value || static::eq($value, $expect, $message);
     }
 
     /**
@@ -1157,7 +1299,11 @@ trait Mixin
      */
     public static function allEq($value, $expect, $message = '')
     {
-        static::__callStatic('allEq', array($value, $expect, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::eq($entry, $expect, $message);
+        }
     }
 
     /**
@@ -1171,7 +1317,7 @@ trait Mixin
      */
     public static function nullOrNotEq($value, $expect, $message = '')
     {
-        static::__callStatic('nullOrNotEq', array($value, $expect, $message));
+        null === $value || static::notEq($value, $expect, $message);
     }
 
     /**
@@ -1185,7 +1331,11 @@ trait Mixin
      */
     public static function allNotEq($value, $expect, $message = '')
     {
-        static::__callStatic('allNotEq', array($value, $expect, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::notEq($entry, $expect, $message);
+        }
     }
 
     /**
@@ -1201,7 +1351,7 @@ trait Mixin
      */
     public static function nullOrSame($value, $expect, $message = '')
     {
-        static::__callStatic('nullOrSame', array($value, $expect, $message));
+        null === $value || static::same($value, $expect, $message);
     }
 
     /**
@@ -1217,7 +1367,11 @@ trait Mixin
      */
     public static function allSame($value, $expect, $message = '')
     {
-        static::__callStatic('allSame', array($value, $expect, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::same($entry, $expect, $message);
+        }
     }
 
     /**
@@ -1233,7 +1387,7 @@ trait Mixin
      */
     public static function nullOrNotSame($value, $expect, $message = '')
     {
-        static::__callStatic('nullOrNotSame', array($value, $expect, $message));
+        null === $value || static::notSame($value, $expect, $message);
     }
 
     /**
@@ -1249,7 +1403,11 @@ trait Mixin
      */
     public static function allNotSame($value, $expect, $message = '')
     {
-        static::__callStatic('allNotSame', array($value, $expect, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::notSame($entry, $expect, $message);
+        }
     }
 
     /**
@@ -1265,7 +1423,7 @@ trait Mixin
      */
     public static function nullOrGreaterThan($value, $limit, $message = '')
     {
-        static::__callStatic('nullOrGreaterThan', array($value, $limit, $message));
+        null === $value || static::greaterThan($value, $limit, $message);
     }
 
     /**
@@ -1281,7 +1439,11 @@ trait Mixin
      */
     public static function allGreaterThan($value, $limit, $message = '')
     {
-        static::__callStatic('allGreaterThan', array($value, $limit, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::greaterThan($entry, $limit, $message);
+        }
     }
 
     /**
@@ -1297,7 +1459,7 @@ trait Mixin
      */
     public static function nullOrGreaterThanEq($value, $limit, $message = '')
     {
-        static::__callStatic('nullOrGreaterThanEq', array($value, $limit, $message));
+        null === $value || static::greaterThanEq($value, $limit, $message);
     }
 
     /**
@@ -1313,7 +1475,11 @@ trait Mixin
      */
     public static function allGreaterThanEq($value, $limit, $message = '')
     {
-        static::__callStatic('allGreaterThanEq', array($value, $limit, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::greaterThanEq($entry, $limit, $message);
+        }
     }
 
     /**
@@ -1329,7 +1495,7 @@ trait Mixin
      */
     public static function nullOrLessThan($value, $limit, $message = '')
     {
-        static::__callStatic('nullOrLessThan', array($value, $limit, $message));
+        null === $value || static::lessThan($value, $limit, $message);
     }
 
     /**
@@ -1345,7 +1511,11 @@ trait Mixin
      */
     public static function allLessThan($value, $limit, $message = '')
     {
-        static::__callStatic('allLessThan', array($value, $limit, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::lessThan($entry, $limit, $message);
+        }
     }
 
     /**
@@ -1361,7 +1531,7 @@ trait Mixin
      */
     public static function nullOrLessThanEq($value, $limit, $message = '')
     {
-        static::__callStatic('nullOrLessThanEq', array($value, $limit, $message));
+        null === $value || static::lessThanEq($value, $limit, $message);
     }
 
     /**
@@ -1377,7 +1547,11 @@ trait Mixin
      */
     public static function allLessThanEq($value, $limit, $message = '')
     {
-        static::__callStatic('allLessThanEq', array($value, $limit, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::lessThanEq($entry, $limit, $message);
+        }
     }
 
     /**
@@ -1394,7 +1568,7 @@ trait Mixin
      */
     public static function nullOrRange($value, $min, $max, $message = '')
     {
-        static::__callStatic('nullOrRange', array($value, $min, $max, $message));
+        null === $value || static::range($value, $min, $max, $message);
     }
 
     /**
@@ -1411,7 +1585,11 @@ trait Mixin
      */
     public static function allRange($value, $min, $max, $message = '')
     {
-        static::__callStatic('allRange', array($value, $min, $max, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::range($entry, $min, $max, $message);
+        }
     }
 
     /**
@@ -1427,7 +1605,7 @@ trait Mixin
      */
     public static function nullOrOneOf($value, $values, $message = '')
     {
-        static::__callStatic('nullOrOneOf', array($value, $values, $message));
+        null === $value || static::oneOf($value, $values, $message);
     }
 
     /**
@@ -1443,7 +1621,11 @@ trait Mixin
      */
     public static function allOneOf($value, $values, $message = '')
     {
-        static::__callStatic('allOneOf', array($value, $values, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::oneOf($entry, $values, $message);
+        }
     }
 
     /**
@@ -1459,7 +1641,7 @@ trait Mixin
      */
     public static function nullOrInArray($value, $values, $message = '')
     {
-        static::__callStatic('nullOrInArray', array($value, $values, $message));
+        null === $value || static::inArray($value, $values, $message);
     }
 
     /**
@@ -1475,7 +1657,11 @@ trait Mixin
      */
     public static function allInArray($value, $values, $message = '')
     {
-        static::__callStatic('allInArray', array($value, $values, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::inArray($entry, $values, $message);
+        }
     }
 
     /**
@@ -1491,7 +1677,7 @@ trait Mixin
      */
     public static function nullOrContains($value, $subString, $message = '')
     {
-        static::__callStatic('nullOrContains', array($value, $subString, $message));
+        null === $value || static::contains($value, $subString, $message);
     }
 
     /**
@@ -1507,7 +1693,11 @@ trait Mixin
      */
     public static function allContains($value, $subString, $message = '')
     {
-        static::__callStatic('allContains', array($value, $subString, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::contains($entry, $subString, $message);
+        }
     }
 
     /**
@@ -1523,7 +1713,7 @@ trait Mixin
      */
     public static function nullOrNotContains($value, $subString, $message = '')
     {
-        static::__callStatic('nullOrNotContains', array($value, $subString, $message));
+        null === $value || static::notContains($value, $subString, $message);
     }
 
     /**
@@ -1539,7 +1729,11 @@ trait Mixin
      */
     public static function allNotContains($value, $subString, $message = '')
     {
-        static::__callStatic('allNotContains', array($value, $subString, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::notContains($entry, $subString, $message);
+        }
     }
 
     /**
@@ -1554,7 +1748,7 @@ trait Mixin
      */
     public static function nullOrNotWhitespaceOnly($value, $message = '')
     {
-        static::__callStatic('nullOrNotWhitespaceOnly', array($value, $message));
+        null === $value || static::notWhitespaceOnly($value, $message);
     }
 
     /**
@@ -1569,7 +1763,11 @@ trait Mixin
      */
     public static function allNotWhitespaceOnly($value, $message = '')
     {
-        static::__callStatic('allNotWhitespaceOnly', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::notWhitespaceOnly($entry, $message);
+        }
     }
 
     /**
@@ -1585,7 +1783,7 @@ trait Mixin
      */
     public static function nullOrStartsWith($value, $prefix, $message = '')
     {
-        static::__callStatic('nullOrStartsWith', array($value, $prefix, $message));
+        null === $value || static::startsWith($value, $prefix, $message);
     }
 
     /**
@@ -1601,7 +1799,11 @@ trait Mixin
      */
     public static function allStartsWith($value, $prefix, $message = '')
     {
-        static::__callStatic('allStartsWith', array($value, $prefix, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::startsWith($entry, $prefix, $message);
+        }
     }
 
     /**
@@ -1617,7 +1819,7 @@ trait Mixin
      */
     public static function nullOrNotStartsWith($value, $prefix, $message = '')
     {
-        static::__callStatic('nullOrNotStartsWith', array($value, $prefix, $message));
+        null === $value || static::notStartsWith($value, $prefix, $message);
     }
 
     /**
@@ -1633,7 +1835,11 @@ trait Mixin
      */
     public static function allNotStartsWith($value, $prefix, $message = '')
     {
-        static::__callStatic('allNotStartsWith', array($value, $prefix, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::notStartsWith($entry, $prefix, $message);
+        }
     }
 
     /**
@@ -1648,7 +1854,7 @@ trait Mixin
      */
     public static function nullOrStartsWithLetter($value, $message = '')
     {
-        static::__callStatic('nullOrStartsWithLetter', array($value, $message));
+        null === $value || static::startsWithLetter($value, $message);
     }
 
     /**
@@ -1663,7 +1869,11 @@ trait Mixin
      */
     public static function allStartsWithLetter($value, $message = '')
     {
-        static::__callStatic('allStartsWithLetter', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::startsWithLetter($entry, $message);
+        }
     }
 
     /**
@@ -1679,7 +1889,7 @@ trait Mixin
      */
     public static function nullOrEndsWith($value, $suffix, $message = '')
     {
-        static::__callStatic('nullOrEndsWith', array($value, $suffix, $message));
+        null === $value || static::endsWith($value, $suffix, $message);
     }
 
     /**
@@ -1695,7 +1905,11 @@ trait Mixin
      */
     public static function allEndsWith($value, $suffix, $message = '')
     {
-        static::__callStatic('allEndsWith', array($value, $suffix, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::endsWith($entry, $suffix, $message);
+        }
     }
 
     /**
@@ -1711,7 +1925,7 @@ trait Mixin
      */
     public static function nullOrNotEndsWith($value, $suffix, $message = '')
     {
-        static::__callStatic('nullOrNotEndsWith', array($value, $suffix, $message));
+        null === $value || static::notEndsWith($value, $suffix, $message);
     }
 
     /**
@@ -1727,7 +1941,11 @@ trait Mixin
      */
     public static function allNotEndsWith($value, $suffix, $message = '')
     {
-        static::__callStatic('allNotEndsWith', array($value, $suffix, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::notEndsWith($entry, $suffix, $message);
+        }
     }
 
     /**
@@ -1743,7 +1961,7 @@ trait Mixin
      */
     public static function nullOrRegex($value, $pattern, $message = '')
     {
-        static::__callStatic('nullOrRegex', array($value, $pattern, $message));
+        null === $value || static::regex($value, $pattern, $message);
     }
 
     /**
@@ -1759,7 +1977,11 @@ trait Mixin
      */
     public static function allRegex($value, $pattern, $message = '')
     {
-        static::__callStatic('allRegex', array($value, $pattern, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::regex($entry, $pattern, $message);
+        }
     }
 
     /**
@@ -1775,7 +1997,7 @@ trait Mixin
      */
     public static function nullOrNotRegex($value, $pattern, $message = '')
     {
-        static::__callStatic('nullOrNotRegex', array($value, $pattern, $message));
+        null === $value || static::notRegex($value, $pattern, $message);
     }
 
     /**
@@ -1791,7 +2013,11 @@ trait Mixin
      */
     public static function allNotRegex($value, $pattern, $message = '')
     {
-        static::__callStatic('allNotRegex', array($value, $pattern, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::notRegex($entry, $pattern, $message);
+        }
     }
 
     /**
@@ -1806,7 +2032,7 @@ trait Mixin
      */
     public static function nullOrUnicodeLetters($value, $message = '')
     {
-        static::__callStatic('nullOrUnicodeLetters', array($value, $message));
+        null === $value || static::unicodeLetters($value, $message);
     }
 
     /**
@@ -1821,7 +2047,11 @@ trait Mixin
      */
     public static function allUnicodeLetters($value, $message = '')
     {
-        static::__callStatic('allUnicodeLetters', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::unicodeLetters($entry, $message);
+        }
     }
 
     /**
@@ -1836,7 +2066,7 @@ trait Mixin
      */
     public static function nullOrAlpha($value, $message = '')
     {
-        static::__callStatic('nullOrAlpha', array($value, $message));
+        null === $value || static::alpha($value, $message);
     }
 
     /**
@@ -1851,7 +2081,11 @@ trait Mixin
      */
     public static function allAlpha($value, $message = '')
     {
-        static::__callStatic('allAlpha', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::alpha($entry, $message);
+        }
     }
 
     /**
@@ -1866,7 +2100,7 @@ trait Mixin
      */
     public static function nullOrDigits($value, $message = '')
     {
-        static::__callStatic('nullOrDigits', array($value, $message));
+        null === $value || static::digits($value, $message);
     }
 
     /**
@@ -1881,7 +2115,11 @@ trait Mixin
      */
     public static function allDigits($value, $message = '')
     {
-        static::__callStatic('allDigits', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::digits($entry, $message);
+        }
     }
 
     /**
@@ -1896,7 +2134,7 @@ trait Mixin
      */
     public static function nullOrAlnum($value, $message = '')
     {
-        static::__callStatic('nullOrAlnum', array($value, $message));
+        null === $value || static::alnum($value, $message);
     }
 
     /**
@@ -1911,7 +2149,11 @@ trait Mixin
      */
     public static function allAlnum($value, $message = '')
     {
-        static::__callStatic('allAlnum', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::alnum($entry, $message);
+        }
     }
 
     /**
@@ -1927,7 +2169,7 @@ trait Mixin
      */
     public static function nullOrLower($value, $message = '')
     {
-        static::__callStatic('nullOrLower', array($value, $message));
+        null === $value || static::lower($value, $message);
     }
 
     /**
@@ -1943,7 +2185,11 @@ trait Mixin
      */
     public static function allLower($value, $message = '')
     {
-        static::__callStatic('allLower', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::lower($entry, $message);
+        }
     }
 
     /**
@@ -1958,7 +2204,7 @@ trait Mixin
      */
     public static function nullOrUpper($value, $message = '')
     {
-        static::__callStatic('nullOrUpper', array($value, $message));
+        null === $value || static::upper($value, $message);
     }
 
     /**
@@ -1973,7 +2219,11 @@ trait Mixin
      */
     public static function allUpper($value, $message = '')
     {
-        static::__callStatic('allUpper', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::upper($entry, $message);
+        }
     }
 
     /**
@@ -1989,7 +2239,7 @@ trait Mixin
      */
     public static function nullOrLength($value, $length, $message = '')
     {
-        static::__callStatic('nullOrLength', array($value, $length, $message));
+        null === $value || static::length($value, $length, $message);
     }
 
     /**
@@ -2005,7 +2255,11 @@ trait Mixin
      */
     public static function allLength($value, $length, $message = '')
     {
-        static::__callStatic('allLength', array($value, $length, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::length($entry, $length, $message);
+        }
     }
 
     /**
@@ -2021,7 +2275,7 @@ trait Mixin
      */
     public static function nullOrMinLength($value, $min, $message = '')
     {
-        static::__callStatic('nullOrMinLength', array($value, $min, $message));
+        null === $value || static::minLength($value, $min, $message);
     }
 
     /**
@@ -2037,7 +2291,11 @@ trait Mixin
      */
     public static function allMinLength($value, $min, $message = '')
     {
-        static::__callStatic('allMinLength', array($value, $min, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::minLength($entry, $min, $message);
+        }
     }
 
     /**
@@ -2053,7 +2311,7 @@ trait Mixin
      */
     public static function nullOrMaxLength($value, $max, $message = '')
     {
-        static::__callStatic('nullOrMaxLength', array($value, $max, $message));
+        null === $value || static::maxLength($value, $max, $message);
     }
 
     /**
@@ -2069,7 +2327,11 @@ trait Mixin
      */
     public static function allMaxLength($value, $max, $message = '')
     {
-        static::__callStatic('allMaxLength', array($value, $max, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::maxLength($entry, $max, $message);
+        }
     }
 
     /**
@@ -2086,7 +2348,7 @@ trait Mixin
      */
     public static function nullOrLengthBetween($value, $min, $max, $message = '')
     {
-        static::__callStatic('nullOrLengthBetween', array($value, $min, $max, $message));
+        null === $value || static::lengthBetween($value, $min, $max, $message);
     }
 
     /**
@@ -2103,7 +2365,11 @@ trait Mixin
      */
     public static function allLengthBetween($value, $min, $max, $message = '')
     {
-        static::__callStatic('allLengthBetween', array($value, $min, $max, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::lengthBetween($entry, $min, $max, $message);
+        }
     }
 
     /**
@@ -2116,7 +2382,7 @@ trait Mixin
      */
     public static function nullOrFileExists($value, $message = '')
     {
-        static::__callStatic('nullOrFileExists', array($value, $message));
+        null === $value || static::fileExists($value, $message);
     }
 
     /**
@@ -2129,7 +2395,11 @@ trait Mixin
      */
     public static function allFileExists($value, $message = '')
     {
-        static::__callStatic('allFileExists', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::fileExists($entry, $message);
+        }
     }
 
     /**
@@ -2142,7 +2412,7 @@ trait Mixin
      */
     public static function nullOrFile($value, $message = '')
     {
-        static::__callStatic('nullOrFile', array($value, $message));
+        null === $value || static::file($value, $message);
     }
 
     /**
@@ -2155,7 +2425,11 @@ trait Mixin
      */
     public static function allFile($value, $message = '')
     {
-        static::__callStatic('allFile', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::file($entry, $message);
+        }
     }
 
     /**
@@ -2168,7 +2442,7 @@ trait Mixin
      */
     public static function nullOrDirectory($value, $message = '')
     {
-        static::__callStatic('nullOrDirectory', array($value, $message));
+        null === $value || static::directory($value, $message);
     }
 
     /**
@@ -2181,7 +2455,11 @@ trait Mixin
      */
     public static function allDirectory($value, $message = '')
     {
-        static::__callStatic('allDirectory', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::directory($entry, $message);
+        }
     }
 
     /**
@@ -2194,7 +2472,7 @@ trait Mixin
      */
     public static function nullOrReadable($value, $message = '')
     {
-        static::__callStatic('nullOrReadable', array($value, $message));
+        null === $value || static::readable($value, $message);
     }
 
     /**
@@ -2207,7 +2485,11 @@ trait Mixin
      */
     public static function allReadable($value, $message = '')
     {
-        static::__callStatic('allReadable', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::readable($entry, $message);
+        }
     }
 
     /**
@@ -2220,7 +2502,7 @@ trait Mixin
      */
     public static function nullOrWritable($value, $message = '')
     {
-        static::__callStatic('nullOrWritable', array($value, $message));
+        null === $value || static::writable($value, $message);
     }
 
     /**
@@ -2233,7 +2515,11 @@ trait Mixin
      */
     public static function allWritable($value, $message = '')
     {
-        static::__callStatic('allWritable', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::writable($entry, $message);
+        }
     }
 
     /**
@@ -2248,7 +2534,7 @@ trait Mixin
      */
     public static function nullOrClassExists($value, $message = '')
     {
-        static::__callStatic('nullOrClassExists', array($value, $message));
+        null === $value || static::classExists($value, $message);
     }
 
     /**
@@ -2263,7 +2549,11 @@ trait Mixin
      */
     public static function allClassExists($value, $message = '')
     {
-        static::__callStatic('allClassExists', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::classExists($entry, $message);
+        }
     }
 
     /**
@@ -2282,7 +2572,7 @@ trait Mixin
      */
     public static function nullOrSubclassOf($value, $class, $message = '')
     {
-        static::__callStatic('nullOrSubclassOf', array($value, $class, $message));
+        null === $value || static::subclassOf($value, $class, $message);
     }
 
     /**
@@ -2301,7 +2591,11 @@ trait Mixin
      */
     public static function allSubclassOf($value, $class, $message = '')
     {
-        static::__callStatic('allSubclassOf', array($value, $class, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::subclassOf($entry, $class, $message);
+        }
     }
 
     /**
@@ -2316,7 +2610,7 @@ trait Mixin
      */
     public static function nullOrInterfaceExists($value, $message = '')
     {
-        static::__callStatic('nullOrInterfaceExists', array($value, $message));
+        null === $value || static::interfaceExists($value, $message);
     }
 
     /**
@@ -2331,7 +2625,11 @@ trait Mixin
      */
     public static function allInterfaceExists($value, $message = '')
     {
-        static::__callStatic('allInterfaceExists', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::interfaceExists($entry, $message);
+        }
     }
 
     /**
@@ -2350,7 +2648,7 @@ trait Mixin
      */
     public static function nullOrImplementsInterface($value, $interface, $message = '')
     {
-        static::__callStatic('nullOrImplementsInterface', array($value, $interface, $message));
+        null === $value || static::implementsInterface($value, $interface, $message);
     }
 
     /**
@@ -2369,7 +2667,11 @@ trait Mixin
      */
     public static function allImplementsInterface($value, $interface, $message = '')
     {
-        static::__callStatic('allImplementsInterface', array($value, $interface, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::implementsInterface($entry, $interface, $message);
+        }
     }
 
     /**
@@ -2386,7 +2688,7 @@ trait Mixin
      */
     public static function nullOrPropertyExists($classOrObject, $property, $message = '')
     {
-        static::__callStatic('nullOrPropertyExists', array($classOrObject, $property, $message));
+        null === $classOrObject || static::propertyExists($classOrObject, $property, $message);
     }
 
     /**
@@ -2403,7 +2705,11 @@ trait Mixin
      */
     public static function allPropertyExists($classOrObject, $property, $message = '')
     {
-        static::__callStatic('allPropertyExists', array($classOrObject, $property, $message));
+        static::isIterable($classOrObject);
+
+        foreach ($classOrObject as $entry) {
+            static::propertyExists($entry, $property, $message);
+        }
     }
 
     /**
@@ -2420,7 +2726,7 @@ trait Mixin
      */
     public static function nullOrPropertyNotExists($classOrObject, $property, $message = '')
     {
-        static::__callStatic('nullOrPropertyNotExists', array($classOrObject, $property, $message));
+        null === $classOrObject || static::propertyNotExists($classOrObject, $property, $message);
     }
 
     /**
@@ -2437,7 +2743,11 @@ trait Mixin
      */
     public static function allPropertyNotExists($classOrObject, $property, $message = '')
     {
-        static::__callStatic('allPropertyNotExists', array($classOrObject, $property, $message));
+        static::isIterable($classOrObject);
+
+        foreach ($classOrObject as $entry) {
+            static::propertyNotExists($entry, $property, $message);
+        }
     }
 
     /**
@@ -2454,7 +2764,7 @@ trait Mixin
      */
     public static function nullOrMethodExists($classOrObject, $method, $message = '')
     {
-        static::__callStatic('nullOrMethodExists', array($classOrObject, $method, $message));
+        null === $classOrObject || static::methodExists($classOrObject, $method, $message);
     }
 
     /**
@@ -2471,7 +2781,11 @@ trait Mixin
      */
     public static function allMethodExists($classOrObject, $method, $message = '')
     {
-        static::__callStatic('allMethodExists', array($classOrObject, $method, $message));
+        static::isIterable($classOrObject);
+
+        foreach ($classOrObject as $entry) {
+            static::methodExists($entry, $method, $message);
+        }
     }
 
     /**
@@ -2488,7 +2802,7 @@ trait Mixin
      */
     public static function nullOrMethodNotExists($classOrObject, $method, $message = '')
     {
-        static::__callStatic('nullOrMethodNotExists', array($classOrObject, $method, $message));
+        null === $classOrObject || static::methodNotExists($classOrObject, $method, $message);
     }
 
     /**
@@ -2505,7 +2819,11 @@ trait Mixin
      */
     public static function allMethodNotExists($classOrObject, $method, $message = '')
     {
-        static::__callStatic('allMethodNotExists', array($classOrObject, $method, $message));
+        static::isIterable($classOrObject);
+
+        foreach ($classOrObject as $entry) {
+            static::methodNotExists($entry, $method, $message);
+        }
     }
 
     /**
@@ -2521,7 +2839,7 @@ trait Mixin
      */
     public static function nullOrKeyExists($array, $key, $message = '')
     {
-        static::__callStatic('nullOrKeyExists', array($array, $key, $message));
+        null === $array || static::keyExists($array, $key, $message);
     }
 
     /**
@@ -2537,7 +2855,11 @@ trait Mixin
      */
     public static function allKeyExists($array, $key, $message = '')
     {
-        static::__callStatic('allKeyExists', array($array, $key, $message));
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::keyExists($entry, $key, $message);
+        }
     }
 
     /**
@@ -2553,7 +2875,7 @@ trait Mixin
      */
     public static function nullOrKeyNotExists($array, $key, $message = '')
     {
-        static::__callStatic('nullOrKeyNotExists', array($array, $key, $message));
+        null === $array || static::keyNotExists($array, $key, $message);
     }
 
     /**
@@ -2569,7 +2891,11 @@ trait Mixin
      */
     public static function allKeyNotExists($array, $key, $message = '')
     {
-        static::__callStatic('allKeyNotExists', array($array, $key, $message));
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::keyNotExists($entry, $key, $message);
+        }
     }
 
     /**
@@ -2585,7 +2911,7 @@ trait Mixin
      */
     public static function nullOrValidArrayKey($value, $message = '')
     {
-        static::__callStatic('nullOrValidArrayKey', array($value, $message));
+        null === $value || static::validArrayKey($value, $message);
     }
 
     /**
@@ -2601,7 +2927,11 @@ trait Mixin
      */
     public static function allValidArrayKey($value, $message = '')
     {
-        static::__callStatic('allValidArrayKey', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::validArrayKey($entry, $message);
+        }
     }
 
     /**
@@ -2615,7 +2945,7 @@ trait Mixin
      */
     public static function nullOrCount($array, $number, $message = '')
     {
-        static::__callStatic('nullOrCount', array($array, $number, $message));
+        null === $array || static::count($array, $number, $message);
     }
 
     /**
@@ -2629,7 +2959,11 @@ trait Mixin
      */
     public static function allCount($array, $number, $message = '')
     {
-        static::__callStatic('allCount', array($array, $number, $message));
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::count($entry, $number, $message);
+        }
     }
 
     /**
@@ -2643,7 +2977,7 @@ trait Mixin
      */
     public static function nullOrMinCount($array, $min, $message = '')
     {
-        static::__callStatic('nullOrMinCount', array($array, $min, $message));
+        null === $array || static::minCount($array, $min, $message);
     }
 
     /**
@@ -2657,7 +2991,11 @@ trait Mixin
      */
     public static function allMinCount($array, $min, $message = '')
     {
-        static::__callStatic('allMinCount', array($array, $min, $message));
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::minCount($entry, $min, $message);
+        }
     }
 
     /**
@@ -2671,7 +3009,7 @@ trait Mixin
      */
     public static function nullOrMaxCount($array, $max, $message = '')
     {
-        static::__callStatic('nullOrMaxCount', array($array, $max, $message));
+        null === $array || static::maxCount($array, $max, $message);
     }
 
     /**
@@ -2685,7 +3023,11 @@ trait Mixin
      */
     public static function allMaxCount($array, $max, $message = '')
     {
-        static::__callStatic('allMaxCount', array($array, $max, $message));
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::maxCount($entry, $max, $message);
+        }
     }
 
     /**
@@ -2700,7 +3042,7 @@ trait Mixin
      */
     public static function nullOrCountBetween($array, $min, $max, $message = '')
     {
-        static::__callStatic('nullOrCountBetween', array($array, $min, $max, $message));
+        null === $array || static::countBetween($array, $min, $max, $message);
     }
 
     /**
@@ -2715,7 +3057,11 @@ trait Mixin
      */
     public static function allCountBetween($array, $min, $max, $message = '')
     {
-        static::__callStatic('allCountBetween', array($array, $min, $max, $message));
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::countBetween($entry, $min, $max, $message);
+        }
     }
 
     /**
@@ -2731,7 +3077,7 @@ trait Mixin
      */
     public static function nullOrIsList($array, $message = '')
     {
-        static::__callStatic('nullOrIsList', array($array, $message));
+        null === $array || static::isList($array, $message);
     }
 
     /**
@@ -2747,7 +3093,11 @@ trait Mixin
      */
     public static function allIsList($array, $message = '')
     {
-        static::__callStatic('allIsList', array($array, $message));
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::isList($entry, $message);
+        }
     }
 
     /**
@@ -2763,7 +3113,7 @@ trait Mixin
      */
     public static function nullOrIsNonEmptyList($array, $message = '')
     {
-        static::__callStatic('nullOrIsNonEmptyList', array($array, $message));
+        null === $array || static::isNonEmptyList($array, $message);
     }
 
     /**
@@ -2779,7 +3129,11 @@ trait Mixin
      */
     public static function allIsNonEmptyList($array, $message = '')
     {
-        static::__callStatic('allIsNonEmptyList', array($array, $message));
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::isNonEmptyList($entry, $message);
+        }
     }
 
     /**
@@ -2797,7 +3151,7 @@ trait Mixin
      */
     public static function nullOrIsMap($array, $message = '')
     {
-        static::__callStatic('nullOrIsMap', array($array, $message));
+        null === $array || static::isMap($array, $message);
     }
 
     /**
@@ -2815,7 +3169,11 @@ trait Mixin
      */
     public static function allIsMap($array, $message = '')
     {
-        static::__callStatic('allIsMap', array($array, $message));
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::isMap($entry, $message);
+        }
     }
 
     /**
@@ -2832,7 +3190,7 @@ trait Mixin
      */
     public static function nullOrIsNonEmptyMap($array, $message = '')
     {
-        static::__callStatic('nullOrIsNonEmptyMap', array($array, $message));
+        null === $array || static::isNonEmptyMap($array, $message);
     }
 
     /**
@@ -2849,7 +3207,11 @@ trait Mixin
      */
     public static function allIsNonEmptyMap($array, $message = '')
     {
-        static::__callStatic('allIsNonEmptyMap', array($array, $message));
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::isNonEmptyMap($entry, $message);
+        }
     }
 
     /**
@@ -2864,7 +3226,7 @@ trait Mixin
      */
     public static function nullOrUuid($value, $message = '')
     {
-        static::__callStatic('nullOrUuid', array($value, $message));
+        null === $value || static::uuid($value, $message);
     }
 
     /**
@@ -2879,7 +3241,11 @@ trait Mixin
      */
     public static function allUuid($value, $message = '')
     {
-        static::__callStatic('allUuid', array($value, $message));
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::uuid($entry, $message);
+        }
     }
 
     /**
@@ -2895,7 +3261,7 @@ trait Mixin
      */
     public static function nullOrThrows($expression, $class = 'Exception', $message = '')
     {
-        static::__callStatic('nullOrThrows', array($expression, $class, $message));
+        null === $expression || static::throws($expression, $class, $message);
     }
 
     /**
@@ -2911,6 +3277,10 @@ trait Mixin
      */
     public static function allThrows($expression, $class = 'Exception', $message = '')
     {
-        static::__callStatic('allThrows', array($expression, $class, $message));
+        static::isIterable($expression);
+
+        foreach ($expression as $entry) {
+            static::throws($entry, $class, $message);
+        }
     }
 }

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -10,8 +10,6 @@ use Throwable;
 /**
  * This trait provides nurllOr* and all* variants of assertion base methods.
  * Do not use this trait directly: it will change, and is not designed for reuse.
- *
- * @internal
  */
 trait Mixin
 {


### PR DESCRIPTION
I think there is no reason to call `__callStatic` inside the mixin, instead we can generate the full body code for all `nullOr` and `all` methods.
Advantages: 
* It is easier to follow the code
* It is faster

<details>
<summary>For the performance test I used this code on php 8 with opcache enabled</summary >

```php
<?php

use Webmozart\Assert\Assert;

require __DIR__.'/vendor/autoload.php';

// load class
class_exists(Assert::class);

$t = microtime(true);

for ($i = 0; $i < 1_000_000; ++$i) {
    Assert::nullOrString('');
    //Assert::allString(['']);
}

$t = microtime(true) - $t;

echo number_format($t, 3), 'ms';
```
</details>

| `nullOrString` | time |
| --- | --- |
| magic method without trait | 0.585ms |
| trait with calling `__callStatic` | 0.532ms |
| trait with full body code | 0.116ms |

|  `allString` | time |
| --- | --- |
| magic method without trait | 0.747ms |
| trait with calling `__callStatic` | 0.684ms |
| trait with full body code | 0.171ms |