### PR TITLE
Mark return value of reportInvalidArgument() as never

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -2054,6 +2054,7 @@ class Assert
      * @throws InvalidArgumentException
      *
      * @psalm-pure this method is not supposed to perform side-effects
+     * @psalm-return never
      */
     protected static function reportInvalidArgument($message)
     {


### PR DESCRIPTION
I override this function in my codebase and need more specific return type to satisfy static analysis. So moving this to upstream as well.