### PR TITLE
Drop $ from composer require example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Installation
 
 Use [Composer] to install the package:
 
-```
-$ composer require webmozart/assert
+```bash
+composer require webmozart/assert
 ```
 
 Example


### PR DESCRIPTION
- Added `bash` style to the snippet
- Dropped `$` so it can be copy-pasted easily
- We have enough dollars in php, it's k