### PR TITLE
Remove private empty constructor

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -2060,8 +2060,4 @@ class Assert
     {
         throw new InvalidArgumentException($message);
     }
-
-    private function __construct()
-    {
-    }
 }


### PR DESCRIPTION
I cannot see the usecase of this private constructor as this is default behaviour.