### PR TITLE
Fix deprecated use of 'static' literal string in callable

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -463,7 +463,7 @@ class Assert
         static::reportInvalidArgument(\sprintf(
             $message ?: 'Expected an instance of any of %2$s. Got: %s',
             static::typeToString($value),
-            \implode(', ', \array_map(array('static', 'valueToString'), $classes))
+            \implode(', ', \array_map(array(static::class, 'valueToString'), $classes))
         ));
     }
 
@@ -975,7 +975,7 @@ class Assert
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected one of: %2$s. Got: %s',
                 static::valueToString($value),
-                \implode(', ', \array_map(array('static', 'valueToString'), $values))
+                \implode(', ', \array_map(array(static::class, 'valueToString'), $values))
             ));
         }
     }
@@ -1955,7 +1955,7 @@ class Assert
         if ('nullOr' === \substr($name, 0, 6)) {
             if (null !== $arguments[0]) {
                 $method = \lcfirst(\substr($name, 6));
-                \call_user_func_array(array('static', $method), $arguments);
+                \call_user_func_array(array(static::class, $method), $arguments);
             }
 
             return;
@@ -1970,7 +1970,7 @@ class Assert
             foreach ($arguments[0] as $entry) {
                 $args[0] = $entry;
 
-                \call_user_func_array(array('static', $method), $args);
+                \call_user_func_array(array(static::class, $method), $args);
             }
 
             return;


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate_partially_supported_callables
deprecates this in PHP 8.2 and it will be an error in PHP 9.0
(to use callables that could not be invoked as $callable())

Fixes PHP 8.2 E_DEPRECATED warnings such as `Deprecated: Use of "static" in callables is deprecated in /home/tyson/programming/webmozarts-assert/src/Assert.php on line 978`