### PR TITLE
Old php method syntax correction

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -463,7 +463,7 @@ class Assert
         static::reportInvalidArgument(\sprintf(
             $message ?: 'Expected an instance of any of %2$s. Got: %s',
             static::typeToString($value),
-            \implode(', ', \array_map(array('static', 'valueToString'), $classes))
+            \implode(', ', \array_map(['static', 'valueToString'], $classes))
         ));
     }
 
@@ -485,8 +485,8 @@ class Assert
 
         if (!\is_a($value, $class, \is_string($value))) {
             static::reportInvalidArgument(sprintf(
-                $message ?: 'Expected an instance of this class or to this class among its parents "%2$s". Got: %s',
-                static::valueToString($value),
+                $message ?: 'Expected an instance of this class or to this class among his parents %2$s. Got: %s',
+                static::typeToString($value),
                 $class
             ));
         }
@@ -511,8 +511,8 @@ class Assert
 
         if (\is_a($value, $class, \is_string($value))) {
             static::reportInvalidArgument(sprintf(
-                $message ?: 'Expected an instance of this class or to this class among its parents other than "%2$s". Got: %s',
-                static::valueToString($value),
+                $message ?: 'Expected an instance of this class or to this class among his parents other than %2$s. Got: %s',
+                static::typeToString($value),
                 $class
             ));
         }
@@ -539,9 +539,9 @@ class Assert
         }
 
         static::reportInvalidArgument(sprintf(
-            $message ?: 'Expected an instance of any of this classes or any of those classes among their parents "%2$s". Got: %s',
-            static::valueToString($value),
-            \implode(', ', $classes)
+            $message ?: 'Expected an any of instance of this class or to this class among his parents other than %2$s. Got: %s',
+            static::typeToString($value),
+            \implode(', ', \array_map(['static', 'valueToString'], $classes))
         ));
     }
 
@@ -975,7 +975,7 @@ class Assert
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected one of: %2$s. Got: %s',
                 static::valueToString($value),
-                \implode(', ', \array_map(array('static', 'valueToString'), $values))
+                \implode(', ', \array_map(['static', 'valueToString'], $values))
             ));
         }
     }
@@ -1895,7 +1895,7 @@ class Assert
      */
     public static function uuid($value, $message = '')
     {
-        $value = \str_replace(array('urn:', 'uuid:', '{', '}'), '', $value);
+        $value = \str_replace(['urn:', 'uuid:', '{', '}'], '', $value);
 
         // The nil UUID is special form of UUID that is specified to have all
         // 128 bits set to zero.
@@ -1955,7 +1955,7 @@ class Assert
         if ('nullOr' === \substr($name, 0, 6)) {
             if (null !== $arguments[0]) {
                 $method = \lcfirst(\substr($name, 6));
-                \call_user_func_array(array('static', $method), $arguments);
+                \call_user_func_array(['static', $method], $arguments);
             }
 
             return;
@@ -1970,7 +1970,7 @@ class Assert
             foreach ($arguments[0] as $entry) {
                 $args[0] = $entry;
 
-                \call_user_func_array(array('static', $method), $args);
+                \call_user_func_array(['static', $method], $args);
             }
 
             return;
@@ -2054,7 +2054,6 @@ class Assert
      * @throws InvalidArgumentException
      *
      * @psalm-pure this method is not supposed to perform side-effects
-     * @psalm-return never
      */
     protected static function reportInvalidArgument($message)
     {


### PR DESCRIPTION
Not that this is a problem, I was just testing a php auto-correction algorithm and apparently it worked.