### PR TITLE
Introduce allNullOr methods

### DIFF
--- a/bin/src/MixinGenerator.php
+++ b/bin/src/MixinGenerator.php
@@ -95,9 +95,9 @@ PHP
                 $declaredMethods[] = $all;
             }
 
-            $all = $this->allNullOr($method, 4);
-            if (null !== $all) {
-                $declaredMethods[] = $all;
+            $allNullOr = $this->allNullOr($method, 4);
+            if (null !== $allNullOr) {
+                $declaredMethods[] = $allNullOr;
             }
         }
 
@@ -169,7 +169,7 @@ BODY;
 static::isIterable({$firstParameter});
 
 foreach ({$firstParameter} as \$entry) {
-    null === {$firstParameter} || static::{$method->name}(\$entry, {$parameters});
+    null === \$entry || static::{$method->name}(\$entry, {$parameters});
 }
 BODY;
         });

--- a/bin/src/MixinGenerator.php
+++ b/bin/src/MixinGenerator.php
@@ -45,6 +45,8 @@ final class MixinGenerator
     private $skipMethods = [
         'nullOrNull',           // meaningless
         'nullOrNotNull',        // meaningless
+        'allNullOrNull',        // meaningless
+        'allNullOrNotNull',     // meaningless
     ];
 
     public function generate(): string
@@ -92,12 +94,17 @@ PHP
             if (null !== $all) {
                 $declaredMethods[] = $all;
             }
+
+            $all = $this->allNullOr($method, 4);
+            if (null !== $all) {
+                $declaredMethods[] = $all;
+            }
         }
 
         return \sprintf(
             <<<'PHP'
 /**
- * This trait provides nurllOr* and all* variants of assertion base methods.
+ * This trait provides nurllOr*, all* and allNullOr* variants of assertion base methods.
  * Do not use this trait directly: it will change, and is not designed for reuse.
  */
 trait Mixin
@@ -142,6 +149,27 @@ static::isIterable({$firstParameter});
 
 foreach ({$firstParameter} as \$entry) {
     static::{$method->name}(\$entry, {$parameters});
+}
+BODY;
+        });
+    }
+
+    /**
+     * @param ReflectionMethod $method
+     * @param int              $indent
+     *
+     * @return string|null
+     *
+     * @throws ReflectionException
+     */
+    private function allNullOr(ReflectionMethod $method, int $indent): ?string
+    {
+        return $this->assertion($method, 'allNullOr%s', 'iterable<%s|null>', $indent, function (string $firstParameter, string $parameters) use ($method) {
+            return <<<BODY
+static::isIterable({$firstParameter});
+
+foreach ({$firstParameter} as \$entry) {
+    null === {$firstParameter} || static::{$method->name}(\$entry, {$parameters});
 }
 BODY;
         });

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -65,7 +65,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::string($entry, $message);
+            null === $entry || static::string($entry, $message);
         }
     }
 
@@ -121,7 +121,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::stringNotEmpty($entry, $message);
+            null === $entry || static::stringNotEmpty($entry, $message);
         }
     }
 
@@ -177,7 +177,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::integer($entry, $message);
+            null === $entry || static::integer($entry, $message);
         }
     }
 
@@ -233,7 +233,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::integerish($entry, $message);
+            null === $entry || static::integerish($entry, $message);
         }
     }
 
@@ -289,7 +289,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::positiveInteger($entry, $message);
+            null === $entry || static::positiveInteger($entry, $message);
         }
     }
 
@@ -345,7 +345,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::float($entry, $message);
+            null === $entry || static::float($entry, $message);
         }
     }
 
@@ -401,7 +401,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::numeric($entry, $message);
+            null === $entry || static::numeric($entry, $message);
         }
     }
 
@@ -457,7 +457,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::natural($entry, $message);
+            null === $entry || static::natural($entry, $message);
         }
     }
 
@@ -513,7 +513,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::boolean($entry, $message);
+            null === $entry || static::boolean($entry, $message);
         }
     }
 
@@ -569,7 +569,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::scalar($entry, $message);
+            null === $entry || static::scalar($entry, $message);
         }
     }
 
@@ -625,7 +625,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::object($entry, $message);
+            null === $entry || static::object($entry, $message);
         }
     }
 
@@ -684,7 +684,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::resource($entry, $type, $message);
+            null === $entry || static::resource($entry, $type, $message);
         }
     }
 
@@ -740,7 +740,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isCallable($entry, $message);
+            null === $entry || static::isCallable($entry, $message);
         }
     }
 
@@ -796,7 +796,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isArray($entry, $message);
+            null === $entry || static::isArray($entry, $message);
         }
     }
 
@@ -858,7 +858,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isTraversable($entry, $message);
+            null === $entry || static::isTraversable($entry, $message);
         }
     }
 
@@ -914,7 +914,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isArrayAccessible($entry, $message);
+            null === $entry || static::isArrayAccessible($entry, $message);
         }
     }
 
@@ -970,7 +970,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isCountable($entry, $message);
+            null === $entry || static::isCountable($entry, $message);
         }
     }
 
@@ -1026,7 +1026,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isIterable($entry, $message);
+            null === $entry || static::isIterable($entry, $message);
         }
     }
 
@@ -1091,7 +1091,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isInstanceOf($entry, $class, $message);
+            null === $entry || static::isInstanceOf($entry, $class, $message);
         }
     }
 
@@ -1154,7 +1154,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::notInstanceOf($entry, $class, $message);
+            null === $entry || static::notInstanceOf($entry, $class, $message);
         }
     }
 
@@ -1213,7 +1213,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isInstanceOfAny($entry, $classes, $message);
+            null === $entry || static::isInstanceOfAny($entry, $classes, $message);
         }
     }
 
@@ -1278,7 +1278,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isAOf($entry, $class, $message);
+            null === $entry || static::isAOf($entry, $class, $message);
         }
     }
 
@@ -1342,7 +1342,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isNotA($entry, $class, $message);
+            null === $entry || static::isNotA($entry, $class, $message);
         }
     }
 
@@ -1401,7 +1401,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isAnyOf($entry, $classes, $message);
+            null === $entry || static::isAnyOf($entry, $classes, $message);
         }
     }
 
@@ -1457,7 +1457,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::isEmpty($entry, $message);
+            null === $entry || static::isEmpty($entry, $message);
         }
     }
 
@@ -1511,7 +1511,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::notEmpty($entry, $message);
+            null === $entry || static::notEmpty($entry, $message);
         }
     }
 
@@ -1606,7 +1606,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::true($entry, $message);
+            null === $entry || static::true($entry, $message);
         }
     }
 
@@ -1662,7 +1662,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::false($entry, $message);
+            null === $entry || static::false($entry, $message);
         }
     }
 
@@ -1716,7 +1716,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::notFalse($entry, $message);
+            null === $entry || static::notFalse($entry, $message);
         }
     }
 
@@ -1763,7 +1763,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::ip($entry, $message);
+            null === $entry || static::ip($entry, $message);
         }
     }
 
@@ -1810,7 +1810,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::ipv4($entry, $message);
+            null === $entry || static::ipv4($entry, $message);
         }
     }
 
@@ -1857,7 +1857,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::ipv6($entry, $message);
+            null === $entry || static::ipv6($entry, $message);
         }
     }
 
@@ -1904,7 +1904,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::email($entry, $message);
+            null === $entry || static::email($entry, $message);
         }
     }
 
@@ -1951,7 +1951,7 @@ trait Mixin
         static::isIterable($values);
 
         foreach ($values as $entry) {
-            null === $values || static::uniqueValues($entry, $message);
+            null === $entry || static::uniqueValues($entry, $message);
         }
     }
 
@@ -2001,7 +2001,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::eq($entry, $expect, $message);
+            null === $entry || static::eq($entry, $expect, $message);
         }
     }
 
@@ -2051,7 +2051,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::notEq($entry, $expect, $message);
+            null === $entry || static::notEq($entry, $expect, $message);
         }
     }
 
@@ -2107,7 +2107,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::same($entry, $expect, $message);
+            null === $entry || static::same($entry, $expect, $message);
         }
     }
 
@@ -2163,7 +2163,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::notSame($entry, $expect, $message);
+            null === $entry || static::notSame($entry, $expect, $message);
         }
     }
 
@@ -2219,7 +2219,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::greaterThan($entry, $limit, $message);
+            null === $entry || static::greaterThan($entry, $limit, $message);
         }
     }
 
@@ -2275,7 +2275,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::greaterThanEq($entry, $limit, $message);
+            null === $entry || static::greaterThanEq($entry, $limit, $message);
         }
     }
 
@@ -2331,7 +2331,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::lessThan($entry, $limit, $message);
+            null === $entry || static::lessThan($entry, $limit, $message);
         }
     }
 
@@ -2387,7 +2387,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::lessThanEq($entry, $limit, $message);
+            null === $entry || static::lessThanEq($entry, $limit, $message);
         }
     }
 
@@ -2446,7 +2446,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::range($entry, $min, $max, $message);
+            null === $entry || static::range($entry, $min, $max, $message);
         }
     }
 
@@ -2502,7 +2502,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::oneOf($entry, $values, $message);
+            null === $entry || static::oneOf($entry, $values, $message);
         }
     }
 
@@ -2558,7 +2558,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::inArray($entry, $values, $message);
+            null === $entry || static::inArray($entry, $values, $message);
         }
     }
 
@@ -2614,7 +2614,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::contains($entry, $subString, $message);
+            null === $entry || static::contains($entry, $subString, $message);
         }
     }
 
@@ -2670,7 +2670,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::notContains($entry, $subString, $message);
+            null === $entry || static::notContains($entry, $subString, $message);
         }
     }
 
@@ -2723,7 +2723,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::notWhitespaceOnly($entry, $message);
+            null === $entry || static::notWhitespaceOnly($entry, $message);
         }
     }
 
@@ -2779,7 +2779,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::startsWith($entry, $prefix, $message);
+            null === $entry || static::startsWith($entry, $prefix, $message);
         }
     }
 
@@ -2835,7 +2835,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::notStartsWith($entry, $prefix, $message);
+            null === $entry || static::notStartsWith($entry, $prefix, $message);
         }
     }
 
@@ -2888,7 +2888,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::startsWithLetter($entry, $message);
+            null === $entry || static::startsWithLetter($entry, $message);
         }
     }
 
@@ -2944,7 +2944,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::endsWith($entry, $suffix, $message);
+            null === $entry || static::endsWith($entry, $suffix, $message);
         }
     }
 
@@ -3000,7 +3000,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::notEndsWith($entry, $suffix, $message);
+            null === $entry || static::notEndsWith($entry, $suffix, $message);
         }
     }
 
@@ -3056,7 +3056,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::regex($entry, $pattern, $message);
+            null === $entry || static::regex($entry, $pattern, $message);
         }
     }
 
@@ -3112,7 +3112,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::notRegex($entry, $pattern, $message);
+            null === $entry || static::notRegex($entry, $pattern, $message);
         }
     }
 
@@ -3165,7 +3165,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::unicodeLetters($entry, $message);
+            null === $entry || static::unicodeLetters($entry, $message);
         }
     }
 
@@ -3218,7 +3218,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::alpha($entry, $message);
+            null === $entry || static::alpha($entry, $message);
         }
     }
 
@@ -3271,7 +3271,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::digits($entry, $message);
+            null === $entry || static::digits($entry, $message);
         }
     }
 
@@ -3324,7 +3324,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::alnum($entry, $message);
+            null === $entry || static::alnum($entry, $message);
         }
     }
 
@@ -3380,7 +3380,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::lower($entry, $message);
+            null === $entry || static::lower($entry, $message);
         }
     }
 
@@ -3434,7 +3434,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::upper($entry, $message);
+            null === $entry || static::upper($entry, $message);
         }
     }
 
@@ -3490,7 +3490,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::length($entry, $length, $message);
+            null === $entry || static::length($entry, $length, $message);
         }
     }
 
@@ -3546,7 +3546,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::minLength($entry, $min, $message);
+            null === $entry || static::minLength($entry, $min, $message);
         }
     }
 
@@ -3602,7 +3602,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::maxLength($entry, $max, $message);
+            null === $entry || static::maxLength($entry, $max, $message);
         }
     }
 
@@ -3661,7 +3661,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::lengthBetween($entry, $min, $max, $message);
+            null === $entry || static::lengthBetween($entry, $min, $max, $message);
         }
     }
 
@@ -3708,7 +3708,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::fileExists($entry, $message);
+            null === $entry || static::fileExists($entry, $message);
         }
     }
 
@@ -3755,7 +3755,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::file($entry, $message);
+            null === $entry || static::file($entry, $message);
         }
     }
 
@@ -3802,7 +3802,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::directory($entry, $message);
+            null === $entry || static::directory($entry, $message);
         }
     }
 
@@ -3849,7 +3849,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::readable($entry, $message);
+            null === $entry || static::readable($entry, $message);
         }
     }
 
@@ -3896,7 +3896,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::writable($entry, $message);
+            null === $entry || static::writable($entry, $message);
         }
     }
 
@@ -3949,7 +3949,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::classExists($entry, $message);
+            null === $entry || static::classExists($entry, $message);
         }
     }
 
@@ -4014,7 +4014,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::subclassOf($entry, $class, $message);
+            null === $entry || static::subclassOf($entry, $class, $message);
         }
     }
 
@@ -4067,7 +4067,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::interfaceExists($entry, $message);
+            null === $entry || static::interfaceExists($entry, $message);
         }
     }
 
@@ -4132,7 +4132,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::implementsInterface($entry, $interface, $message);
+            null === $entry || static::implementsInterface($entry, $interface, $message);
         }
     }
 
@@ -4191,7 +4191,7 @@ trait Mixin
         static::isIterable($classOrObject);
 
         foreach ($classOrObject as $entry) {
-            null === $classOrObject || static::propertyExists($entry, $property, $message);
+            null === $entry || static::propertyExists($entry, $property, $message);
         }
     }
 
@@ -4250,7 +4250,7 @@ trait Mixin
         static::isIterable($classOrObject);
 
         foreach ($classOrObject as $entry) {
-            null === $classOrObject || static::propertyNotExists($entry, $property, $message);
+            null === $entry || static::propertyNotExists($entry, $property, $message);
         }
     }
 
@@ -4309,7 +4309,7 @@ trait Mixin
         static::isIterable($classOrObject);
 
         foreach ($classOrObject as $entry) {
-            null === $classOrObject || static::methodExists($entry, $method, $message);
+            null === $entry || static::methodExists($entry, $method, $message);
         }
     }
 
@@ -4368,7 +4368,7 @@ trait Mixin
         static::isIterable($classOrObject);
 
         foreach ($classOrObject as $entry) {
-            null === $classOrObject || static::methodNotExists($entry, $method, $message);
+            null === $entry || static::methodNotExists($entry, $method, $message);
         }
     }
 
@@ -4424,7 +4424,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            null === $array || static::keyExists($entry, $key, $message);
+            null === $entry || static::keyExists($entry, $key, $message);
         }
     }
 
@@ -4480,7 +4480,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            null === $array || static::keyNotExists($entry, $key, $message);
+            null === $entry || static::keyNotExists($entry, $key, $message);
         }
     }
 
@@ -4536,7 +4536,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::validArrayKey($entry, $message);
+            null === $entry || static::validArrayKey($entry, $message);
         }
     }
 
@@ -4586,7 +4586,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            null === $array || static::count($entry, $number, $message);
+            null === $entry || static::count($entry, $number, $message);
         }
     }
 
@@ -4636,7 +4636,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            null === $array || static::minCount($entry, $min, $message);
+            null === $entry || static::minCount($entry, $min, $message);
         }
     }
 
@@ -4686,7 +4686,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            null === $array || static::maxCount($entry, $max, $message);
+            null === $entry || static::maxCount($entry, $max, $message);
         }
     }
 
@@ -4739,7 +4739,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            null === $array || static::countBetween($entry, $min, $max, $message);
+            null === $entry || static::countBetween($entry, $min, $max, $message);
         }
     }
 
@@ -4795,7 +4795,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            null === $array || static::isList($entry, $message);
+            null === $entry || static::isList($entry, $message);
         }
     }
 
@@ -4851,7 +4851,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            null === $array || static::isNonEmptyList($entry, $message);
+            null === $entry || static::isNonEmptyList($entry, $message);
         }
     }
 
@@ -4913,7 +4913,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            null === $array || static::isMap($entry, $message);
+            null === $entry || static::isMap($entry, $message);
         }
     }
 
@@ -4974,7 +4974,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            null === $array || static::isNonEmptyMap($entry, $message);
+            null === $entry || static::isNonEmptyMap($entry, $message);
         }
     }
 
@@ -5027,7 +5027,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            null === $value || static::uuid($entry, $message);
+            null === $entry || static::uuid($entry, $message);
         }
     }
 
@@ -5083,7 +5083,7 @@ trait Mixin
         static::isIterable($expression);
 
         foreach ($expression as $entry) {
-            null === $expression || static::throws($entry, $class, $message);
+            null === $entry || static::throws($entry, $class, $message);
         }
     }
 }

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -51,6 +51,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<string|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrString($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrString($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert non-empty-string|null $value
      *
      * @param mixed  $value
@@ -82,6 +102,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::stringNotEmpty($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-assert iterable<non-empty-string|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrStringNotEmpty($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrStringNotEmpty($entry, $message);
         }
     }
 
@@ -123,6 +163,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<int|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrInteger($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrInteger($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert numeric|null $value
      *
      * @param mixed  $value
@@ -149,6 +209,26 @@ trait Mixin
      * @return void
      */
     public static function allIntegerish($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::integerish($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-assert iterable<numeric|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIntegerish($value, $message = '')
     {
         static::isIterable($value);
 
@@ -195,6 +275,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<positive-int|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrPositiveInteger($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrPositiveInteger($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert float|null $value
      *
      * @param mixed  $value
@@ -226,6 +326,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::float($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-assert iterable<float|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrFloat($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrFloat($entry, $message);
         }
     }
 
@@ -267,6 +387,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<numeric|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNumeric($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNumeric($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert positive-int|0|null $value
      *
      * @param mixed  $value
@@ -298,6 +438,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::natural($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-assert iterable<positive-int|0|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNatural($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNatural($entry, $message);
         }
     }
 
@@ -339,6 +499,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<bool|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrBoolean($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrBoolean($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert scalar|null $value
      *
      * @param mixed  $value
@@ -375,6 +555,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<scalar|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrScalar($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrScalar($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert object|null $value
      *
      * @param mixed  $value
@@ -406,6 +606,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::object($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-assert iterable<object|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrObject($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrObject($entry, $message);
         }
     }
 
@@ -449,6 +669,27 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<resource|null> $value
+     *
+     * @param mixed       $value
+     * @param string|null $type    type of resource this should be. @see https://www.php.net/manual/en/function.get-resource-type.php
+     * @param string      $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrResource($value, $type = null, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrResource($entry, $type, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert callable|null $value
      *
      * @param mixed  $value
@@ -485,6 +726,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<callable|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsCallable($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIsCallable($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert array|null $value
      *
      * @param mixed  $value
@@ -516,6 +777,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::isArray($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-assert iterable<array|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsArray($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIsArray($entry, $message);
         }
     }
 
@@ -597,6 +878,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<array|ArrayAccess|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsArrayAccessible($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIsArrayAccessible($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert countable|null $value
      *
      * @param mixed  $value
@@ -633,6 +934,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<countable|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsCountable($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIsCountable($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert iterable|null $value
      *
      * @param mixed  $value
@@ -664,6 +985,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::isIterable($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-assert iterable<iterable|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsIterable($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIsIterable($entry, $message);
         }
     }
 
@@ -713,6 +1054,29 @@ trait Mixin
      * @psalm-pure
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $class
+     * @psalm-assert iterable<ExpectedType|null> $value
+     *
+     * @param mixed         $value
+     * @param string|object $class
+     * @param string        $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsInstanceOf($value, $class, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIsInstanceOf($entry, $class, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $class
      *
      * @param mixed         $value
      * @param string|object $class
@@ -751,6 +1115,28 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $class
+     *
+     * @param mixed         $value
+     * @param string|object $class
+     * @param string        $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNotInstanceOf($value, $class, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNotInstanceOf($entry, $class, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-param array<class-string> $classes
      *
      * @param mixed                $value
@@ -784,6 +1170,27 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::isInstanceOfAny($entry, $classes, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-param array<class-string> $classes
+     *
+     * @param mixed                $value
+     * @param array<object|string> $classes
+     * @param string               $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsInstanceOfAny($value, $classes, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIsInstanceOfAny($entry, $classes, $message);
         }
     }
 
@@ -831,6 +1238,29 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $class
+     * @psalm-assert iterable<ExpectedType|class-string<ExpectedType>|null> $value
+     *
+     * @param iterable<object|string> $value
+     * @param string                  $class
+     * @param string                  $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsAOf($value, $class, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIsAOf($entry, $class, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-template UnexpectedType of object
      * @psalm-param class-string<UnexpectedType> $class
      *
@@ -866,6 +1296,28 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::isNotA($entry, $class, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-template UnexpectedType of object
+     * @psalm-param class-string<UnexpectedType> $class
+     *
+     * @param iterable<object|string> $value
+     * @param string                  $class
+     * @param string                  $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsNotA($value, $class, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIsNotA($entry, $class, $message);
         }
     }
 
@@ -909,6 +1361,27 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-param array<class-string> $classes
+     *
+     * @param iterable<object|string> $value
+     * @param string[]                $classes
+     * @param string                  $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsAnyOf($value, $classes, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIsAnyOf($entry, $classes, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert empty $value
      *
      * @param mixed  $value
@@ -945,6 +1418,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<empty|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsEmpty($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIsEmpty($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      *
      * @param mixed  $value
      * @param string $message
@@ -974,6 +1467,25 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::notEmpty($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNotEmpty($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNotEmpty($entry, $message);
         }
     }
 
@@ -1054,6 +1566,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<true|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrTrue($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrTrue($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert false|null $value
      *
      * @param mixed  $value
@@ -1090,6 +1622,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<false|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrFalse($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrFalse($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      *
      * @param mixed  $value
      * @param string $message
@@ -1119,6 +1671,25 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::notFalse($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNotFalse($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNotFalse($entry, $message);
         }
     }
 
@@ -1160,6 +1731,23 @@ trait Mixin
      *
      * @return void
      */
+    public static function allNullOrIp($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIp($entry, $message);
+        }
+    }
+
+    /**
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
     public static function nullOrIpv4($value, $message = '')
     {
         null === $value || static::ipv4($value, $message);
@@ -1179,6 +1767,23 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::ipv4($entry, $message);
+        }
+    }
+
+    /**
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIpv4($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIpv4($entry, $message);
         }
     }
 
@@ -1220,6 +1825,23 @@ trait Mixin
      *
      * @return void
      */
+    public static function allNullOrIpv6($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrIpv6($entry, $message);
+        }
+    }
+
+    /**
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
     public static function nullOrEmail($value, $message = '')
     {
         null === $value || static::email($value, $message);
@@ -1239,6 +1861,23 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::email($entry, $message);
+        }
+    }
+
+    /**
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrEmail($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrEmail($entry, $message);
         }
     }
 
@@ -1269,6 +1908,23 @@ trait Mixin
 
         foreach ($values as $entry) {
             static::uniqueValues($entry, $message);
+        }
+    }
+
+    /**
+     * @param iterable<array> $values
+     * @param string          $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrUniqueValues($values, $message = '')
+    {
+        static::isIterable($values);
+
+        foreach ($values as $entry) {
+            static::nullOrUniqueValues($entry, $message);
         }
     }
 
@@ -1313,6 +1969,24 @@ trait Mixin
      *
      * @return void
      */
+    public static function allNullOrEq($value, $expect, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrEq($entry, $expect, $message);
+        }
+    }
+
+    /**
+     * @param mixed  $value
+     * @param mixed  $expect
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
     public static function nullOrNotEq($value, $expect, $message = '')
     {
         null === $value || static::notEq($value, $expect, $message);
@@ -1333,6 +2007,24 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::notEq($entry, $expect, $message);
+        }
+    }
+
+    /**
+     * @param mixed  $value
+     * @param mixed  $expect
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNotEq($value, $expect, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNotEq($entry, $expect, $message);
         }
     }
 
@@ -1383,6 +2075,26 @@ trait Mixin
      *
      * @return void
      */
+    public static function allNullOrSame($value, $expect, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrSame($entry, $expect, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param mixed  $expect
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
     public static function nullOrNotSame($value, $expect, $message = '')
     {
         null === $value || static::notSame($value, $expect, $message);
@@ -1405,6 +2117,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::notSame($entry, $expect, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param mixed  $expect
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNotSame($value, $expect, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNotSame($entry, $expect, $message);
         }
     }
 
@@ -1455,6 +2187,26 @@ trait Mixin
      *
      * @return void
      */
+    public static function allNullOrGreaterThan($value, $limit, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrGreaterThan($entry, $limit, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param mixed  $limit
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
     public static function nullOrGreaterThanEq($value, $limit, $message = '')
     {
         null === $value || static::greaterThanEq($value, $limit, $message);
@@ -1477,6 +2229,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::greaterThanEq($entry, $limit, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param mixed  $limit
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrGreaterThanEq($value, $limit, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrGreaterThanEq($entry, $limit, $message);
         }
     }
 
@@ -1527,6 +2299,26 @@ trait Mixin
      *
      * @return void
      */
+    public static function allNullOrLessThan($value, $limit, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrLessThan($entry, $limit, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param mixed  $limit
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
     public static function nullOrLessThanEq($value, $limit, $message = '')
     {
         null === $value || static::lessThanEq($value, $limit, $message);
@@ -1549,6 +2341,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::lessThanEq($entry, $limit, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param mixed  $limit
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrLessThanEq($value, $limit, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrLessThanEq($entry, $limit, $message);
         }
     }
 
@@ -1587,6 +2399,27 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::range($entry, $min, $max, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param mixed  $min
+     * @param mixed  $max
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrRange($value, $min, $max, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrRange($entry, $min, $max, $message);
         }
     }
 
@@ -1637,6 +2470,26 @@ trait Mixin
      *
      * @return void
      */
+    public static function allNullOrOneOf($value, $values, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrOneOf($entry, $values, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param array  $values
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
     public static function nullOrInArray($value, $values, $message = '')
     {
         null === $value || static::inArray($value, $values, $message);
@@ -1659,6 +2512,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::inArray($entry, $values, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param array  $values
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrInArray($value, $values, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrInArray($entry, $values, $message);
         }
     }
 
@@ -1701,6 +2574,26 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param iterable<string|null> $value
+     * @param string                $subString
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrContains($value, $subString, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrContains($entry, $subString, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
      * @param string|null $value
      * @param string      $subString
      * @param string      $message
@@ -1737,6 +2630,26 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param iterable<string|null> $value
+     * @param string                $subString
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNotContains($value, $subString, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNotContains($entry, $subString, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
      * @param string|null $value
      * @param string      $message
      *
@@ -1765,6 +2678,25 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::notWhitespaceOnly($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param iterable<string|null> $value
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNotWhitespaceOnly($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNotWhitespaceOnly($entry, $message);
         }
     }
 
@@ -1807,6 +2739,26 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param iterable<string|null> $value
+     * @param string                $prefix
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrStartsWith($value, $prefix, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrStartsWith($entry, $prefix, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
      * @param string|null $value
      * @param string      $prefix
      * @param string      $message
@@ -1843,6 +2795,26 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param iterable<string|null> $value
+     * @param string                $prefix
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNotStartsWith($value, $prefix, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNotStartsWith($entry, $prefix, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
      * @param mixed  $value
      * @param string $message
      *
@@ -1871,6 +2843,25 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::startsWithLetter($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrStartsWithLetter($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrStartsWithLetter($entry, $message);
         }
     }
 
@@ -1913,6 +2904,26 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param iterable<string|null> $value
+     * @param string                $suffix
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrEndsWith($value, $suffix, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrEndsWith($entry, $suffix, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
      * @param string|null $value
      * @param string      $suffix
      * @param string      $message
@@ -1943,6 +2954,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::notEndsWith($entry, $suffix, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param iterable<string|null> $value
+     * @param string                $suffix
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNotEndsWith($value, $suffix, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNotEndsWith($entry, $suffix, $message);
         }
     }
 
@@ -1985,6 +3016,26 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param iterable<string|null> $value
+     * @param string                $pattern
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrRegex($value, $pattern, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrRegex($entry, $pattern, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
      * @param string|null $value
      * @param string      $pattern
      * @param string      $message
@@ -2015,6 +3066,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::notRegex($entry, $pattern, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param iterable<string|null> $value
+     * @param string                $pattern
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrNotRegex($value, $pattern, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrNotRegex($entry, $pattern, $message);
         }
     }
 
@@ -2062,6 +3133,25 @@ trait Mixin
      *
      * @return void
      */
+    public static function allNullOrUnicodeLetters($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrUnicodeLetters($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
     public static function nullOrAlpha($value, $message = '')
     {
         null === $value || static::alpha($value, $message);
@@ -2083,6 +3173,25 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::alpha($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrAlpha($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrAlpha($entry, $message);
         }
     }
 
@@ -2123,6 +3232,25 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param iterable<string|null> $value
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrDigits($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrDigits($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
      * @param string|null $value
      * @param string      $message
      *
@@ -2151,6 +3279,25 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::alnum($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param iterable<string|null> $value
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrAlnum($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrAlnum($entry, $message);
         }
     }
 
@@ -2192,6 +3339,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<lowercase-string|null> $value
+     *
+     * @param iterable<string|null> $value
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrLower($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrLower($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      *
      * @param string|null $value
      * @param string      $message
@@ -2221,6 +3388,25 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::upper($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param iterable<string|null> $value
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrUpper($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrUpper($entry, $message);
         }
     }
 
@@ -2263,6 +3449,26 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param iterable<string|null> $value
+     * @param int                   $length
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrLength($value, $length, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrLength($entry, $length, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
      * @param string|null $value
      * @param int|float   $min
      * @param string      $message
@@ -2293,6 +3499,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::minLength($entry, $min, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param iterable<string|null> $value
+     * @param int|float             $min
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrMinLength($value, $min, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrMinLength($entry, $min, $message);
         }
     }
 
@@ -2335,6 +3561,26 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param iterable<string|null> $value
+     * @param int|float             $max
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrMaxLength($value, $max, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrMaxLength($entry, $max, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
      * @param string|null $value
      * @param int|float   $min
      * @param int|float   $max
@@ -2367,6 +3613,27 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::lengthBetween($entry, $min, $max, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param iterable<string|null> $value
+     * @param int|float             $min
+     * @param int|float             $max
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrLengthBetween($value, $min, $max, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrLengthBetween($entry, $min, $max, $message);
         }
     }
 
@@ -2408,6 +3675,23 @@ trait Mixin
      *
      * @return void
      */
+    public static function allNullOrFileExists($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrFileExists($entry, $message);
+        }
+    }
+
+    /**
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
     public static function nullOrFile($value, $message = '')
     {
         null === $value || static::file($value, $message);
@@ -2427,6 +3711,23 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::file($entry, $message);
+        }
+    }
+
+    /**
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrFile($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrFile($entry, $message);
         }
     }
 
@@ -2461,6 +3762,23 @@ trait Mixin
     }
 
     /**
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrDirectory($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrDirectory($entry, $message);
+        }
+    }
+
+    /**
      * @param string|null $value
      * @param string      $message
      *
@@ -2474,8 +3792,8 @@ trait Mixin
     }
 
     /**
-     * @param iterable<string> $value
-     * @param string           $message
+     * @param iterable<string|null> $value
+     * @param string                $message
      *
      * @throws InvalidArgumentException
      *
@@ -2487,6 +3805,23 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::readable($entry, $message);
+        }
+    }
+
+    /**
+     * @param iterable<string|null> $value
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrReadable($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrReadable($entry, $message);
         }
     }
 
@@ -2521,6 +3856,23 @@ trait Mixin
     }
 
     /**
+     * @param iterable<string|null> $value
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrWritable($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrWritable($entry, $message);
+        }
+    }
+
+    /**
      * @psalm-assert class-string|null $value
      *
      * @param mixed  $value
@@ -2551,6 +3903,25 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::classExists($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-assert iterable<class-string|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrClassExists($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrClassExists($entry, $message);
         }
     }
 
@@ -2597,6 +3968,29 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $class
+     * @psalm-assert iterable<class-string<ExpectedType>|ExpectedType|null> $value
+     *
+     * @param mixed         $value
+     * @param string|object $class
+     * @param string        $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrSubclassOf($value, $class, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrSubclassOf($entry, $class, $message);
+        }
+    }
+
+    /**
      * @psalm-assert class-string|null $value
      *
      * @param mixed  $value
@@ -2627,6 +4021,25 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::interfaceExists($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-assert iterable<class-string|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrInterfaceExists($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrInterfaceExists($entry, $message);
         }
     }
 
@@ -2674,6 +4087,29 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $interface
+     * @psalm-assert iterable<class-string<ExpectedType>|null> $value
+     *
+     * @param mixed  $value
+     * @param mixed  $interface
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrImplementsInterface($value, $interface, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrImplementsInterface($entry, $interface, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-param class-string|object|null $classOrObject
      *
      * @param string|object|null $classOrObject
@@ -2707,6 +4143,27 @@ trait Mixin
 
         foreach ($classOrObject as $entry) {
             static::propertyExists($entry, $property, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-param iterable<class-string|object|null> $classOrObject
+     *
+     * @param iterable<string|object|null> $classOrObject
+     * @param mixed                        $property
+     * @param string                       $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrPropertyExists($classOrObject, $property, $message = '')
+    {
+        static::isIterable($classOrObject);
+
+        foreach ($classOrObject as $entry) {
+            static::nullOrPropertyExists($entry, $property, $message);
         }
     }
 
@@ -2750,6 +4207,27 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-param iterable<class-string|object|null> $classOrObject
+     *
+     * @param iterable<string|object|null> $classOrObject
+     * @param mixed                        $property
+     * @param string                       $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrPropertyNotExists($classOrObject, $property, $message = '')
+    {
+        static::isIterable($classOrObject);
+
+        foreach ($classOrObject as $entry) {
+            static::nullOrPropertyNotExists($entry, $property, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-param class-string|object|null $classOrObject
      *
      * @param string|object|null $classOrObject
@@ -2783,6 +4261,27 @@ trait Mixin
 
         foreach ($classOrObject as $entry) {
             static::methodExists($entry, $method, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-param iterable<class-string|object|null> $classOrObject
+     *
+     * @param iterable<string|object|null> $classOrObject
+     * @param mixed                        $method
+     * @param string                       $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrMethodExists($classOrObject, $method, $message = '')
+    {
+        static::isIterable($classOrObject);
+
+        foreach ($classOrObject as $entry) {
+            static::nullOrMethodExists($entry, $method, $message);
         }
     }
 
@@ -2826,6 +4325,27 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-param iterable<class-string|object|null> $classOrObject
+     *
+     * @param iterable<string|object|null> $classOrObject
+     * @param mixed                        $method
+     * @param string                       $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrMethodNotExists($classOrObject, $method, $message = '')
+    {
+        static::isIterable($classOrObject);
+
+        foreach ($classOrObject as $entry) {
+            static::nullOrMethodNotExists($entry, $method, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      *
      * @param array|null $array
      * @param string|int $key
@@ -2857,6 +4377,26 @@ trait Mixin
 
         foreach ($array as $entry) {
             static::keyExists($entry, $key, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param iterable<array|null> $array
+     * @param string|int           $key
+     * @param string               $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrKeyExists($array, $key, $message = '')
+    {
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::nullOrKeyExists($entry, $key, $message);
         }
     }
 
@@ -2898,6 +4438,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     *
+     * @param iterable<array|null> $array
+     * @param string|int           $key
+     * @param string               $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrKeyNotExists($array, $key, $message = '')
+    {
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::nullOrKeyNotExists($entry, $key, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert array-key|null $value
      *
      * @param mixed  $value
@@ -2929,6 +4489,26 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::validArrayKey($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-assert iterable<array-key|null> $value
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrValidArrayKey($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrValidArrayKey($entry, $message);
         }
     }
 
@@ -2965,6 +4545,24 @@ trait Mixin
     }
 
     /**
+     * @param iterable<Countable|array|null> $array
+     * @param int                            $number
+     * @param string                         $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrCount($array, $number, $message = '')
+    {
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::nullOrCount($entry, $number, $message);
+        }
+    }
+
+    /**
      * @param Countable|array|null $array
      * @param int|float            $min
      * @param string               $message
@@ -2988,6 +4586,24 @@ trait Mixin
      * @return void
      */
     public static function allMinCount($array, $min, $message = '')
+    {
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::minCount($entry, $min, $message);
+        }
+    }
+
+    /**
+     * @param iterable<Countable|array|null> $array
+     * @param int|float                      $min
+     * @param string                         $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrMinCount($array, $min, $message = '')
     {
         static::isIterable($array);
 
@@ -3029,6 +4645,24 @@ trait Mixin
     }
 
     /**
+     * @param iterable<Countable|array|null> $array
+     * @param int|float                      $max
+     * @param string                         $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrMaxCount($array, $max, $message = '')
+    {
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::nullOrMaxCount($entry, $max, $message);
+        }
+    }
+
+    /**
      * @param Countable|array|null $array
      * @param int|float            $min
      * @param int|float            $max
@@ -3059,6 +4693,25 @@ trait Mixin
 
         foreach ($array as $entry) {
             static::countBetween($entry, $min, $max, $message);
+        }
+    }
+
+    /**
+     * @param iterable<Countable|array|null> $array
+     * @param int|float                      $min
+     * @param int|float                      $max
+     * @param string                         $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrCountBetween($array, $min, $max, $message = '')
+    {
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::nullOrCountBetween($entry, $min, $max, $message);
         }
     }
 
@@ -3100,6 +4753,26 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<list|null> $array
+     *
+     * @param mixed  $array
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsList($array, $message = '')
+    {
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::nullOrIsList($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
      * @psalm-assert non-empty-list|null $array
      *
      * @param mixed  $array
@@ -3131,6 +4804,26 @@ trait Mixin
 
         foreach ($array as $entry) {
             static::isNonEmptyList($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-assert iterable<non-empty-list|null> $array
+     *
+     * @param mixed  $array
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsNonEmptyList($array, $message = '')
+    {
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::nullOrIsNonEmptyList($entry, $message);
         }
     }
 
@@ -3177,6 +4870,28 @@ trait Mixin
     /**
      * @psalm-pure
      * @psalm-template T
+     * @psalm-param iterable<mixed|array<T>|null> $array
+     * @psalm-assert iterable<array<string, T>|null> $array
+     *
+     * @param mixed  $array
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsMap($array, $message = '')
+    {
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::nullOrIsMap($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-template T
      * @psalm-param mixed|array<T>|null $array
      *
      * @param mixed  $array
@@ -3209,6 +4924,27 @@ trait Mixin
 
         foreach ($array as $entry) {
             static::isNonEmptyMap($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-template T
+     * @psalm-param iterable<mixed|array<T>|null> $array
+     *
+     * @param mixed  $array
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsNonEmptyMap($array, $message = '')
+    {
+        static::isIterable($array);
+
+        foreach ($array as $entry) {
+            static::nullOrIsNonEmptyMap($entry, $message);
         }
     }
 
@@ -3247,6 +4983,25 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
+     * @param iterable<string|null> $value
+     * @param string                $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrUuid($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrUuid($entry, $message);
+        }
+    }
+
+    /**
      * @psalm-param class-string<Throwable> $class
      *
      * @param Closure|null $expression
@@ -3279,6 +5034,26 @@ trait Mixin
 
         foreach ($expression as $entry) {
             static::throws($entry, $class, $message);
+        }
+    }
+
+    /**
+     * @psalm-param class-string<Throwable> $class
+     *
+     * @param iterable<Closure|null> $expression
+     * @param string                 $class
+     * @param string                 $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrThrows($expression, $class = 'Exception', $message = '')
+    {
+        static::isIterable($expression);
+
+        foreach ($expression as $entry) {
+            static::nullOrThrows($entry, $class, $message);
         }
     }
 }

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -8,7 +8,7 @@ use Countable;
 use Throwable;
 
 /**
- * This trait provides nurllOr* and all* variants of assertion base methods.
+ * This trait provides nurllOr*, all* and allNullOr* variants of assertion base methods.
  * Do not use this trait directly: it will change, and is not designed for reuse.
  */
 trait Mixin
@@ -65,7 +65,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrString($entry, $message);
+            null === $value || static::string($entry, $message);
         }
     }
 
@@ -121,7 +121,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrStringNotEmpty($entry, $message);
+            null === $value || static::stringNotEmpty($entry, $message);
         }
     }
 
@@ -177,7 +177,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrInteger($entry, $message);
+            null === $value || static::integer($entry, $message);
         }
     }
 
@@ -233,7 +233,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::integerish($entry, $message);
+            null === $value || static::integerish($entry, $message);
         }
     }
 
@@ -289,7 +289,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrPositiveInteger($entry, $message);
+            null === $value || static::positiveInteger($entry, $message);
         }
     }
 
@@ -345,7 +345,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrFloat($entry, $message);
+            null === $value || static::float($entry, $message);
         }
     }
 
@@ -401,7 +401,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNumeric($entry, $message);
+            null === $value || static::numeric($entry, $message);
         }
     }
 
@@ -457,7 +457,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNatural($entry, $message);
+            null === $value || static::natural($entry, $message);
         }
     }
 
@@ -513,7 +513,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrBoolean($entry, $message);
+            null === $value || static::boolean($entry, $message);
         }
     }
 
@@ -569,7 +569,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrScalar($entry, $message);
+            null === $value || static::scalar($entry, $message);
         }
     }
 
@@ -625,7 +625,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrObject($entry, $message);
+            null === $value || static::object($entry, $message);
         }
     }
 
@@ -684,7 +684,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrResource($entry, $type, $message);
+            null === $value || static::resource($entry, $type, $message);
         }
     }
 
@@ -740,7 +740,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIsCallable($entry, $message);
+            null === $value || static::isCallable($entry, $message);
         }
     }
 
@@ -796,7 +796,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIsArray($entry, $message);
+            null === $value || static::isArray($entry, $message);
         }
     }
 
@@ -837,6 +837,28 @@ trait Mixin
 
         foreach ($value as $entry) {
             static::isTraversable($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-assert iterable<iterable|null> $value
+     *
+     * @deprecated use "isIterable" or "isInstanceOf" instead
+     *
+     * @param mixed  $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    public static function allNullOrIsTraversable($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            null === $value || static::isTraversable($entry, $message);
         }
     }
 
@@ -892,7 +914,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIsArrayAccessible($entry, $message);
+            null === $value || static::isArrayAccessible($entry, $message);
         }
     }
 
@@ -948,7 +970,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIsCountable($entry, $message);
+            null === $value || static::isCountable($entry, $message);
         }
     }
 
@@ -1004,7 +1026,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIsIterable($entry, $message);
+            null === $value || static::isIterable($entry, $message);
         }
     }
 
@@ -1069,7 +1091,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIsInstanceOf($entry, $class, $message);
+            null === $value || static::isInstanceOf($entry, $class, $message);
         }
     }
 
@@ -1117,6 +1139,7 @@ trait Mixin
      * @psalm-pure
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $class
+     * @psalm-assert iterable<!ExpectedType|null> $value
      *
      * @param mixed         $value
      * @param string|object $class
@@ -1131,7 +1154,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNotInstanceOf($entry, $class, $message);
+            null === $value || static::notInstanceOf($entry, $class, $message);
         }
     }
 
@@ -1190,7 +1213,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIsInstanceOfAny($entry, $classes, $message);
+            null === $value || static::isInstanceOfAny($entry, $classes, $message);
         }
     }
 
@@ -1242,9 +1265,9 @@ trait Mixin
      * @psalm-param class-string<ExpectedType> $class
      * @psalm-assert iterable<ExpectedType|class-string<ExpectedType>|null> $value
      *
-     * @param iterable<object|string> $value
-     * @param string                  $class
-     * @param string                  $message
+     * @param iterable<object|string|null> $value
+     * @param string                       $class
+     * @param string                       $message
      *
      * @throws InvalidArgumentException
      *
@@ -1255,7 +1278,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIsAOf($entry, $class, $message);
+            null === $value || static::isAOf($entry, $class, $message);
         }
     }
 
@@ -1303,10 +1326,12 @@ trait Mixin
      * @psalm-pure
      * @psalm-template UnexpectedType of object
      * @psalm-param class-string<UnexpectedType> $class
+     * @psalm-assert iterable<!UnexpectedType|null> $value
+     * @psalm-assert iterable<!class-string<UnexpectedType>|null> $value
      *
-     * @param iterable<object|string> $value
-     * @param string                  $class
-     * @param string                  $message
+     * @param iterable<object|string|null> $value
+     * @param string                       $class
+     * @param string                       $message
      *
      * @throws InvalidArgumentException
      *
@@ -1317,7 +1342,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIsNotA($entry, $class, $message);
+            null === $value || static::isNotA($entry, $class, $message);
         }
     }
 
@@ -1363,9 +1388,9 @@ trait Mixin
      * @psalm-pure
      * @psalm-param array<class-string> $classes
      *
-     * @param iterable<object|string> $value
-     * @param string[]                $classes
-     * @param string                  $message
+     * @param iterable<object|string|null> $value
+     * @param string[]                     $classes
+     * @param string                       $message
      *
      * @throws InvalidArgumentException
      *
@@ -1376,7 +1401,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIsAnyOf($entry, $classes, $message);
+            null === $value || static::isAnyOf($entry, $classes, $message);
         }
     }
 
@@ -1432,7 +1457,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIsEmpty($entry, $message);
+            null === $value || static::isEmpty($entry, $message);
         }
     }
 
@@ -1472,6 +1497,7 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<!empty|null> $value
      *
      * @param mixed  $value
      * @param string $message
@@ -1485,7 +1511,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNotEmpty($entry, $message);
+            null === $value || static::notEmpty($entry, $message);
         }
     }
 
@@ -1580,7 +1606,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrTrue($entry, $message);
+            null === $value || static::true($entry, $message);
         }
     }
 
@@ -1636,7 +1662,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrFalse($entry, $message);
+            null === $value || static::false($entry, $message);
         }
     }
 
@@ -1676,6 +1702,7 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<!false|null> $value
      *
      * @param mixed  $value
      * @param string $message
@@ -1689,7 +1716,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNotFalse($entry, $message);
+            null === $value || static::notFalse($entry, $message);
         }
     }
 
@@ -1736,7 +1763,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIp($entry, $message);
+            null === $value || static::ip($entry, $message);
         }
     }
 
@@ -1783,7 +1810,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIpv4($entry, $message);
+            null === $value || static::ipv4($entry, $message);
         }
     }
 
@@ -1830,7 +1857,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrIpv6($entry, $message);
+            null === $value || static::ipv6($entry, $message);
         }
     }
 
@@ -1877,7 +1904,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrEmail($entry, $message);
+            null === $value || static::email($entry, $message);
         }
     }
 
@@ -1912,8 +1939,8 @@ trait Mixin
     }
 
     /**
-     * @param iterable<array> $values
-     * @param string          $message
+     * @param iterable<array|null> $values
+     * @param string               $message
      *
      * @throws InvalidArgumentException
      *
@@ -1924,7 +1951,7 @@ trait Mixin
         static::isIterable($values);
 
         foreach ($values as $entry) {
-            static::nullOrUniqueValues($entry, $message);
+            null === $values || static::uniqueValues($entry, $message);
         }
     }
 
@@ -1974,7 +2001,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrEq($entry, $expect, $message);
+            null === $value || static::eq($entry, $expect, $message);
         }
     }
 
@@ -2024,7 +2051,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNotEq($entry, $expect, $message);
+            null === $value || static::notEq($entry, $expect, $message);
         }
     }
 
@@ -2080,7 +2107,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrSame($entry, $expect, $message);
+            null === $value || static::same($entry, $expect, $message);
         }
     }
 
@@ -2136,7 +2163,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNotSame($entry, $expect, $message);
+            null === $value || static::notSame($entry, $expect, $message);
         }
     }
 
@@ -2192,7 +2219,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrGreaterThan($entry, $limit, $message);
+            null === $value || static::greaterThan($entry, $limit, $message);
         }
     }
 
@@ -2248,7 +2275,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrGreaterThanEq($entry, $limit, $message);
+            null === $value || static::greaterThanEq($entry, $limit, $message);
         }
     }
 
@@ -2304,7 +2331,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrLessThan($entry, $limit, $message);
+            null === $value || static::lessThan($entry, $limit, $message);
         }
     }
 
@@ -2360,7 +2387,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrLessThanEq($entry, $limit, $message);
+            null === $value || static::lessThanEq($entry, $limit, $message);
         }
     }
 
@@ -2419,7 +2446,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrRange($entry, $min, $max, $message);
+            null === $value || static::range($entry, $min, $max, $message);
         }
     }
 
@@ -2475,7 +2502,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrOneOf($entry, $values, $message);
+            null === $value || static::oneOf($entry, $values, $message);
         }
     }
 
@@ -2531,7 +2558,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrInArray($entry, $values, $message);
+            null === $value || static::inArray($entry, $values, $message);
         }
     }
 
@@ -2587,7 +2614,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrContains($entry, $subString, $message);
+            null === $value || static::contains($entry, $subString, $message);
         }
     }
 
@@ -2643,7 +2670,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNotContains($entry, $subString, $message);
+            null === $value || static::notContains($entry, $subString, $message);
         }
     }
 
@@ -2696,7 +2723,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNotWhitespaceOnly($entry, $message);
+            null === $value || static::notWhitespaceOnly($entry, $message);
         }
     }
 
@@ -2752,7 +2779,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrStartsWith($entry, $prefix, $message);
+            null === $value || static::startsWith($entry, $prefix, $message);
         }
     }
 
@@ -2808,7 +2835,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNotStartsWith($entry, $prefix, $message);
+            null === $value || static::notStartsWith($entry, $prefix, $message);
         }
     }
 
@@ -2861,7 +2888,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrStartsWithLetter($entry, $message);
+            null === $value || static::startsWithLetter($entry, $message);
         }
     }
 
@@ -2917,7 +2944,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrEndsWith($entry, $suffix, $message);
+            null === $value || static::endsWith($entry, $suffix, $message);
         }
     }
 
@@ -2973,7 +3000,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNotEndsWith($entry, $suffix, $message);
+            null === $value || static::notEndsWith($entry, $suffix, $message);
         }
     }
 
@@ -3029,7 +3056,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrRegex($entry, $pattern, $message);
+            null === $value || static::regex($entry, $pattern, $message);
         }
     }
 
@@ -3085,7 +3112,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrNotRegex($entry, $pattern, $message);
+            null === $value || static::notRegex($entry, $pattern, $message);
         }
     }
 
@@ -3138,7 +3165,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrUnicodeLetters($entry, $message);
+            null === $value || static::unicodeLetters($entry, $message);
         }
     }
 
@@ -3191,7 +3218,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrAlpha($entry, $message);
+            null === $value || static::alpha($entry, $message);
         }
     }
 
@@ -3244,7 +3271,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrDigits($entry, $message);
+            null === $value || static::digits($entry, $message);
         }
     }
 
@@ -3297,7 +3324,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrAlnum($entry, $message);
+            null === $value || static::alnum($entry, $message);
         }
     }
 
@@ -3353,7 +3380,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrLower($entry, $message);
+            null === $value || static::lower($entry, $message);
         }
     }
 
@@ -3393,6 +3420,7 @@ trait Mixin
 
     /**
      * @psalm-pure
+     * @psalm-assert iterable<!lowercase-string|null> $value
      *
      * @param iterable<string|null> $value
      * @param string                $message
@@ -3406,7 +3434,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrUpper($entry, $message);
+            null === $value || static::upper($entry, $message);
         }
     }
 
@@ -3462,7 +3490,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrLength($entry, $length, $message);
+            null === $value || static::length($entry, $length, $message);
         }
     }
 
@@ -3518,7 +3546,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrMinLength($entry, $min, $message);
+            null === $value || static::minLength($entry, $min, $message);
         }
     }
 
@@ -3574,7 +3602,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrMaxLength($entry, $max, $message);
+            null === $value || static::maxLength($entry, $max, $message);
         }
     }
 
@@ -3633,7 +3661,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrLengthBetween($entry, $min, $max, $message);
+            null === $value || static::lengthBetween($entry, $min, $max, $message);
         }
     }
 
@@ -3680,7 +3708,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrFileExists($entry, $message);
+            null === $value || static::fileExists($entry, $message);
         }
     }
 
@@ -3727,7 +3755,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrFile($entry, $message);
+            null === $value || static::file($entry, $message);
         }
     }
 
@@ -3774,7 +3802,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrDirectory($entry, $message);
+            null === $value || static::directory($entry, $message);
         }
     }
 
@@ -3792,8 +3820,8 @@ trait Mixin
     }
 
     /**
-     * @param iterable<string|null> $value
-     * @param string                $message
+     * @param iterable<string> $value
+     * @param string           $message
      *
      * @throws InvalidArgumentException
      *
@@ -3821,7 +3849,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrReadable($entry, $message);
+            null === $value || static::readable($entry, $message);
         }
     }
 
@@ -3868,7 +3896,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrWritable($entry, $message);
+            null === $value || static::writable($entry, $message);
         }
     }
 
@@ -3921,7 +3949,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrClassExists($entry, $message);
+            null === $value || static::classExists($entry, $message);
         }
     }
 
@@ -3986,7 +4014,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrSubclassOf($entry, $class, $message);
+            null === $value || static::subclassOf($entry, $class, $message);
         }
     }
 
@@ -4039,7 +4067,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrInterfaceExists($entry, $message);
+            null === $value || static::interfaceExists($entry, $message);
         }
     }
 
@@ -4104,7 +4132,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrImplementsInterface($entry, $interface, $message);
+            null === $value || static::implementsInterface($entry, $interface, $message);
         }
     }
 
@@ -4163,7 +4191,7 @@ trait Mixin
         static::isIterable($classOrObject);
 
         foreach ($classOrObject as $entry) {
-            static::nullOrPropertyExists($entry, $property, $message);
+            null === $classOrObject || static::propertyExists($entry, $property, $message);
         }
     }
 
@@ -4222,7 +4250,7 @@ trait Mixin
         static::isIterable($classOrObject);
 
         foreach ($classOrObject as $entry) {
-            static::nullOrPropertyNotExists($entry, $property, $message);
+            null === $classOrObject || static::propertyNotExists($entry, $property, $message);
         }
     }
 
@@ -4281,7 +4309,7 @@ trait Mixin
         static::isIterable($classOrObject);
 
         foreach ($classOrObject as $entry) {
-            static::nullOrMethodExists($entry, $method, $message);
+            null === $classOrObject || static::methodExists($entry, $method, $message);
         }
     }
 
@@ -4340,7 +4368,7 @@ trait Mixin
         static::isIterable($classOrObject);
 
         foreach ($classOrObject as $entry) {
-            static::nullOrMethodNotExists($entry, $method, $message);
+            null === $classOrObject || static::methodNotExists($entry, $method, $message);
         }
     }
 
@@ -4396,7 +4424,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            static::nullOrKeyExists($entry, $key, $message);
+            null === $array || static::keyExists($entry, $key, $message);
         }
     }
 
@@ -4452,7 +4480,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            static::nullOrKeyNotExists($entry, $key, $message);
+            null === $array || static::keyNotExists($entry, $key, $message);
         }
     }
 
@@ -4508,7 +4536,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrValidArrayKey($entry, $message);
+            null === $value || static::validArrayKey($entry, $message);
         }
     }
 
@@ -4558,7 +4586,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            static::nullOrCount($entry, $number, $message);
+            null === $array || static::count($entry, $number, $message);
         }
     }
 
@@ -4608,7 +4636,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            static::minCount($entry, $min, $message);
+            null === $array || static::minCount($entry, $min, $message);
         }
     }
 
@@ -4658,7 +4686,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            static::nullOrMaxCount($entry, $max, $message);
+            null === $array || static::maxCount($entry, $max, $message);
         }
     }
 
@@ -4711,7 +4739,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            static::nullOrCountBetween($entry, $min, $max, $message);
+            null === $array || static::countBetween($entry, $min, $max, $message);
         }
     }
 
@@ -4767,7 +4795,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            static::nullOrIsList($entry, $message);
+            null === $array || static::isList($entry, $message);
         }
     }
 
@@ -4823,7 +4851,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            static::nullOrIsNonEmptyList($entry, $message);
+            null === $array || static::isNonEmptyList($entry, $message);
         }
     }
 
@@ -4885,7 +4913,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            static::nullOrIsMap($entry, $message);
+            null === $array || static::isMap($entry, $message);
         }
     }
 
@@ -4931,6 +4959,8 @@ trait Mixin
      * @psalm-pure
      * @psalm-template T
      * @psalm-param iterable<mixed|array<T>|null> $array
+     * @psalm-assert iterable<array<string, T>|null> $array
+     * @psalm-assert iterable<!empty|null> $array
      *
      * @param mixed  $array
      * @param string $message
@@ -4944,7 +4974,7 @@ trait Mixin
         static::isIterable($array);
 
         foreach ($array as $entry) {
-            static::nullOrIsNonEmptyMap($entry, $message);
+            null === $array || static::isNonEmptyMap($entry, $message);
         }
     }
 
@@ -4997,7 +5027,7 @@ trait Mixin
         static::isIterable($value);
 
         foreach ($value as $entry) {
-            static::nullOrUuid($entry, $message);
+            null === $value || static::uuid($entry, $message);
         }
     }
 
@@ -5053,7 +5083,7 @@ trait Mixin
         static::isIterable($expression);
 
         foreach ($expression as $entry) {
-            static::nullOrThrows($entry, $class, $message);
+            null === $expression || static::throws($entry, $class, $message);
         }
     }
 }

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -675,6 +675,38 @@ class AssertTest extends TestCase
     /**
      * @dataProvider getTests
      */
+    public function testAllNullOrArray($method, $args, $success, $multibyte = false, $minVersion = null)
+    {
+        if ($minVersion && PHP_VERSION_ID < $minVersion) {
+            $this->markTestSkipped(sprintf('This test requires php %s or upper.', $minVersion));
+
+            return;
+        }
+        if ($multibyte && !function_exists('mb_strlen')) {
+            $this->markTestSkipped('The function mb_strlen() is not available');
+        }
+
+        $arg = array_shift($args);
+
+        if ($arg === null) {
+            $this->addToAssertionCount(1);
+
+            return;
+        }
+
+        if (!$success) {
+            $this->expectException('\InvalidArgumentException');
+        }
+
+        array_unshift($args, array($arg, null));
+
+        call_user_func_array(array('Webmozart\Assert\Assert', 'allNullOr'.ucfirst($method)), $args);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider getTests
+     */
     public function testAllTraversable($method, $args, $success, $multibyte = false, $minVersion = null)
     {
         if ($minVersion && PHP_VERSION_ID < $minVersion) {

--- a/tests/static-analysis/assert-alnum.php
+++ b/tests/static-analysis/assert-alnum.php
@@ -31,9 +31,23 @@ function nullOrAlnum(?string $value): ?string
  *
  * @return iterable<string>
  */
-function allAllnum(iterable $value): iterable
+function allAlnum(iterable $value): iterable
 {
     Assert::allAlnum($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrAlnum(iterable $value): iterable
+{
+    Assert::allNullOrAlnum($value);
 
     return $value;
 }

--- a/tests/static-analysis/assert-alpha.php
+++ b/tests/static-analysis/assert-alpha.php
@@ -45,3 +45,17 @@ function allAlpha($value)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrAlpha($value)
+{
+    Assert::allNullOrAlpha($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-boolean.php
+++ b/tests/static-analysis/assert-boolean.php
@@ -41,3 +41,17 @@ function allBoolean($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<bool|null>
+ */
+function allNullOrBoolean($value): iterable
+{
+    Assert::allNullOrBoolean($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-classExists.php
+++ b/tests/static-analysis/assert-classExists.php
@@ -39,3 +39,15 @@ function allClassExists($value): iterable
 
     return $value;
 }
+
+/**
+ * @param mixed $value
+ *
+ * @return iterable<class-string|null>
+ */
+function allNullOrClassExists($value): iterable
+{
+    Assert::allNullOrClassExists($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-contains.php
+++ b/tests/static-analysis/assert-contains.php
@@ -37,3 +37,17 @@ function allContains(iterable $value, string $subString): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrContains(iterable $value, string $subString): iterable
+{
+    Assert::allNullOrContains($value, $subString);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-count.php
+++ b/tests/static-analysis/assert-count.php
@@ -40,3 +40,15 @@ function allCount(iterable $value, int $number): iterable
 
     return $value;
 }
+
+/**
+ * @param iterable<Countable|array|null> $value
+ *
+ * @return iterable<Countable|array|null>
+ */
+function allNullOrCount(iterable $value, int $number): iterable
+{
+    Assert::allCount($value, $number);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-countBetween.php
+++ b/tests/static-analysis/assert-countBetween.php
@@ -46,3 +46,17 @@ function allCountBetween(iterable $value, $min, $max): iterable
 
     return $value;
 }
+
+/**
+ * @param iterable<Countable|array|null> $value
+ * @param int|float $min
+ * @param int|float $max
+ *
+ * @return iterable<Countable|array|null>
+ */
+function allNullOrCountBetween(iterable $value, $min, $max): iterable
+{
+    Assert::allNullOrCountBetween($value, $min, $max);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-digits.php
+++ b/tests/static-analysis/assert-digits.php
@@ -37,3 +37,17 @@ function allDigits(iterable $value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrDigits(iterable $value): iterable
+{
+    Assert::allNullOrDigits($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-directory.php
+++ b/tests/static-analysis/assert-directory.php
@@ -39,3 +39,15 @@ function allDirectory($value)
 
     return $value;
 }
+
+/**
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrDirectory($value)
+{
+    Assert::allNullOrDirectory($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-email.php
+++ b/tests/static-analysis/assert-email.php
@@ -39,3 +39,15 @@ function allEmail($value)
 
     return $value;
 }
+
+/**
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrEmail($value)
+{
+    Assert::allNullOrEmail($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-endsWith.php
+++ b/tests/static-analysis/assert-endsWith.php
@@ -37,3 +37,17 @@ function allEndsWith(iterable $value, string $suffix): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrEndsWith(iterable $value, string $suffix): iterable
+{
+    Assert::allNullOrEndsWith($value, $suffix);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-eq.php
+++ b/tests/static-analysis/assert-eq.php
@@ -42,3 +42,16 @@ function allEq($value, $expect)
 
     return $value;
 }
+
+/**
+ * @param mixed $value
+ * @param mixed $expect
+ *
+ * @return mixed
+ */
+function allNullOrEq($value, $expect)
+{
+    Assert::allNullOrEq($value, $expect);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-false.php
+++ b/tests/static-analysis/assert-false.php
@@ -45,3 +45,17 @@ function allFalse($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<false|null>
+ */
+function allNullOrFalse($value): iterable
+{
+    Assert::allFalse($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-file.php
+++ b/tests/static-analysis/assert-file.php
@@ -39,3 +39,15 @@ function allFile($value)
 
     return $value;
 }
+
+/**
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrFile($value)
+{
+    Assert::allNullOrFile($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-fileExists.php
+++ b/tests/static-analysis/assert-fileExists.php
@@ -39,3 +39,15 @@ function allFileExists($value)
 
     return $value;
 }
+
+/**
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrFileExists($value)
+{
+    Assert::allNullOrFileExists($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-float.php
+++ b/tests/static-analysis/assert-float.php
@@ -41,3 +41,17 @@ function allFloat($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<float|null>
+ */
+function allNullOrFloat($value): iterable
+{
+    Assert::allNullOrFloat($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-greaterThan.php
+++ b/tests/static-analysis/assert-greaterThan.php
@@ -48,3 +48,18 @@ function allGreaterThan($value, $limit)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ * @param mixed $limit
+ *
+ * @return mixed
+ */
+function allNullOrGreaterThan($value, $limit)
+{
+    Assert::allNullOrGreaterThan($value, $limit);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-greaterThanEq.php
+++ b/tests/static-analysis/assert-greaterThanEq.php
@@ -48,3 +48,18 @@ function allGreaterThanEq($value, $limit)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ * @param mixed $limit
+ *
+ * @return mixed
+ */
+function allNullOrGreaterThanEq($value, $limit)
+{
+    Assert::allNullOrGreaterThanEq($value, $limit);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-implementsInterface.php
+++ b/tests/static-analysis/assert-implementsInterface.php
@@ -46,3 +46,17 @@ function allImplementsInterface($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<class-string<Serializable>|null>
+ */
+function allNullOrImplementsInterface($value): iterable
+{
+    Assert::allNullOrImplementsInterface($value, Serializable::class);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-inArray.php
+++ b/tests/static-analysis/assert-inArray.php
@@ -45,3 +45,17 @@ function allInArray($value, array $values)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrInArray($value, array $values)
+{
+    Assert::allNullOrInArray($value, $values);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-integer.php
+++ b/tests/static-analysis/assert-integer.php
@@ -41,3 +41,17 @@ function allInteger($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<int|null>
+ */
+function allNullOrInteger($value): iterable
+{
+    Assert::allNullOrInteger($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-integerish.php
+++ b/tests/static-analysis/assert-integerish.php
@@ -45,3 +45,17 @@ function allIntegerish($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<numeric|null>
+ */
+function allNullOrIntegerish($value): iterable
+{
+    Assert::allNullOrIntegerish($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-interfaceExists.php
+++ b/tests/static-analysis/assert-interfaceExists.php
@@ -39,3 +39,15 @@ function allInterfaceExists($value): iterable
 
     return $value;
 }
+
+/**
+ * @param mixed $value
+ *
+ * @return iterable<class-string|null>
+ */
+function allNullOrInterfaceExists($value): iterable
+{
+    Assert::allNullOrInterfaceExists($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-ip.php
+++ b/tests/static-analysis/assert-ip.php
@@ -39,3 +39,15 @@ function allIp($value)
 
     return $value;
 }
+
+/**
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrIp($value)
+{
+    Assert::allNullOrIp($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-ipv4.php
+++ b/tests/static-analysis/assert-ipv4.php
@@ -39,3 +39,15 @@ function allIpv4($value)
 
     return $value;
 }
+
+/**
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrIpv4($value)
+{
+    Assert::allNullOrIpv4($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-ipv6.php
+++ b/tests/static-analysis/assert-ipv6.php
@@ -39,3 +39,15 @@ function allIpv6($value)
 
     return $value;
 }
+
+/**
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrIpv6($value)
+{
+    Assert::allNullOrIpv6($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isAOf.php
+++ b/tests/static-analysis/assert-isAOf.php
@@ -46,3 +46,17 @@ function allIsAOf($value)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<object|string|null> $value
+ *
+ * @return iterable<class-string<Serializable>|Serializable|null>
+ */
+function allNullOrIsAOf($value)
+{
+    Assert::allNullOrIsAOf($value, Serializable::class);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isAnyOf.php
+++ b/tests/static-analysis/assert-isAnyOf.php
@@ -48,3 +48,18 @@ function allIsAnyOf($value, array $classes): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<object|string|null> $value
+ * @param array<class-string> $classes
+ *
+ * @return iterable<object|string|null>
+ */
+function allNullOrIsAnyOf($value, array $classes): iterable
+{
+    Assert::allNullOrIsAnyOf($value, $classes);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isArray.php
+++ b/tests/static-analysis/assert-isArray.php
@@ -41,3 +41,17 @@ function allIsArray($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<array|null>
+ */
+function allNullOrIsArray($value): iterable
+{
+    Assert::allNullOrIsArray($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isArrayAccessible.php
+++ b/tests/static-analysis/assert-isArrayAccessible.php
@@ -46,3 +46,17 @@ function allIsArrayAccessible($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<array|ArrayAccess|null>
+ */
+function allNullOrIsArrayAccessible($value): iterable
+{
+    Assert::allNullOrIsArrayAccessible($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isCallable.php
+++ b/tests/static-analysis/assert-isCallable.php
@@ -41,3 +41,17 @@ function allIsCallable($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<callable|null>
+ */
+function allNullOrIsCallable($value): iterable
+{
+    Assert::allNullOrIsCallable($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isCountable.php
+++ b/tests/static-analysis/assert-isCountable.php
@@ -46,3 +46,17 @@ function allIsCountable($value)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<countable|null>
+ */
+function allNullOrIsCountable($value)
+{
+    Assert::allNullOrIsCountable($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isEmpty.php
+++ b/tests/static-analysis/assert-isEmpty.php
@@ -89,3 +89,17 @@ function allIsEmpty($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<empty|null>
+ */
+function allNullOrIsEmpty($value): iterable
+{
+    Assert::allNullOrIsEmpty($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isInstanceOf.php
+++ b/tests/static-analysis/assert-isInstanceOf.php
@@ -42,3 +42,17 @@ function allIsInstanceOf($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<Serializable|null>
+ */
+function allNullOrIsInstanceOf($value): iterable
+{
+    Assert::allNullOrIsInstanceOf($value, Serializable::class);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isInstanceOfAny.php
+++ b/tests/static-analysis/assert-isInstanceOfAny.php
@@ -48,3 +48,18 @@ function allIsInstanceOfAny($value, array $classes)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ * @param array<class-string> $classes
+ *
+ * @return mixed
+ */
+function allNullOrIsInstanceOfAny($value, array $classes)
+{
+    Assert::allNullOrIsInstanceOfAny($value, $classes);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isIterable.php
+++ b/tests/static-analysis/assert-isIterable.php
@@ -41,3 +41,17 @@ function allIsIterable($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<iterable|null>
+ */
+function allNullOrIsIterable($value): iterable
+{
+    Assert::allNullOrIsIterable($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isList.php
+++ b/tests/static-analysis/assert-isList.php
@@ -59,3 +59,17 @@ function allIsList($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<list<mixed>|null>
+ */
+function allNullOrIsList($value): iterable
+{
+    Assert::allNullOrIsList($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isMap.php
+++ b/tests/static-analysis/assert-isMap.php
@@ -76,3 +76,17 @@ function allIsMap(iterable $value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<mixed|array<mixed>> $value
+ *
+ * @return iterable<array<string, mixed>|null>
+ */
+function allNullOrIsMap(iterable $value): iterable
+{
+    Assert::allNullOrIsMap($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isNonEmptyList.php
+++ b/tests/static-analysis/assert-isNonEmptyList.php
@@ -45,3 +45,17 @@ function allIsNonEmptyList($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<non-empty-list<mixed>|null>
+ */
+function allNullOrIsNonEmptyList($value): iterable
+{
+    Assert::allNullOrIsNonEmptyList($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isNonEmptyMap.php
+++ b/tests/static-analysis/assert-isNonEmptyMap.php
@@ -61,3 +61,17 @@ function allIsNonEmptyMap(iterable $value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<mixed|array<mixed>> $value
+ *
+ * @return iterable<mixed|array<mixed>>
+ */
+function allNullOrIsNonEmptyMap(iterable $value): iterable
+{
+    Assert::allNullOrIsNonEmptyMap($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isNotA.php
+++ b/tests/static-analysis/assert-isNotA.php
@@ -47,3 +47,18 @@ function allIsNotA($value, $class): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<object|string|null> $value
+ * @param class-string $class
+ *
+ * @return iterable<object|string|null>
+ */
+function allNullOrIsNotA($value, $class): iterable
+{
+    Assert::allNullOrIsNotA($value, $class);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-keyExists.php
+++ b/tests/static-analysis/assert-keyExists.php
@@ -42,3 +42,18 @@ function allKeyExists(iterable $array, $key): iterable
 
     return $array;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<array|null> $array
+ * @param array-key $key
+ *
+ * @return iterable<array|null>
+ */
+function allNullOrKeyExists(iterable $array, $key): iterable
+{
+    Assert::allNullOrKeyExists($array, $key);
+
+    return $array;
+}

--- a/tests/static-analysis/assert-keyNotExists.php
+++ b/tests/static-analysis/assert-keyNotExists.php
@@ -42,3 +42,18 @@ function allKeyNotExists(iterable $array, $key): iterable
 
     return $array;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<array|null> $array
+ * @param array-key $key
+ *
+ * @return iterable<array|null>
+ */
+function allNullOrKeyNotExists(iterable $array, $key): iterable
+{
+    Assert::allNullOrKeyNotExists($array, $key);
+
+    return $array;
+}

--- a/tests/static-analysis/assert-length.php
+++ b/tests/static-analysis/assert-length.php
@@ -37,3 +37,17 @@ function allLength(iterable $value, int $length): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrLength(iterable $value, int $length): iterable
+{
+    Assert::allNullOrLength($value, $length);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-lengthBetween.php
+++ b/tests/static-analysis/assert-lengthBetween.php
@@ -45,3 +45,19 @@ function allLengthBetween(iterable $value, $min, $max): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ * @param int|float $min
+ * @param int|float $max
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrLengthBetween(iterable $value, $min, $max): iterable
+{
+    Assert::allNullOrLengthBetween($value, $min, $max);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-lessThan.php
+++ b/tests/static-analysis/assert-lessThan.php
@@ -48,3 +48,18 @@ function allLessThan($value, $limit)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ * @param mixed $limit
+ *
+ * @return mixed
+ */
+function allNullOrLessThan($value, $limit)
+{
+    Assert::allNullOrLessThan($value, $limit);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-lessThanEq.php
+++ b/tests/static-analysis/assert-lessThanEq.php
@@ -48,3 +48,18 @@ function allLessThanEq($value, $limit)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ * @param mixed $limit
+ *
+ * @return mixed
+ */
+function allNullOrLessThanEq($value, $limit)
+{
+    Assert::allNullOrLessThanEq($value, $limit);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-lower.php
+++ b/tests/static-analysis/assert-lower.php
@@ -41,3 +41,17 @@ function allLower(iterable $value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<lowercase-string|null>
+ */
+function allNullOrLower(iterable $value): iterable
+{
+    Assert::allNullOrLower($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-maxCount.php
+++ b/tests/static-analysis/assert-maxCount.php
@@ -43,3 +43,16 @@ function allMaxCount(iterable $array, $max): iterable
 
     return $array;
 }
+
+/**
+ * @param iterable<Countable|array|null> $array
+ * @param int|float $max
+ *
+ * @return iterable<Countable|array|null>
+ */
+function allNullOrMaxCount(iterable $array, $max): iterable
+{
+    Assert::allNullOrMaxCount($array, $max);
+
+    return $array;
+}

--- a/tests/static-analysis/assert-maxLength.php
+++ b/tests/static-analysis/assert-maxLength.php
@@ -42,3 +42,18 @@ function allMaxLength(iterable $value, $max): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ * @param int|float $max
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrMaxLength(iterable $value, $max): iterable
+{
+    Assert::allMaxLength($value, $max);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-methodExists.php
+++ b/tests/static-analysis/assert-methodExists.php
@@ -48,3 +48,18 @@ function allMethodExists(iterable $classOrObject, $method): iterable
 
     return $classOrObject;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object|null> $classOrObject
+ * @param mixed $method
+ *
+ * @return iterable<class-string|object|null>
+ */
+function allNullOrMethodExists(iterable $classOrObject, $method): iterable
+{
+    Assert::allNullOrMethodExists($classOrObject, $method);
+
+    return $classOrObject;
+}

--- a/tests/static-analysis/assert-methodNotExists.php
+++ b/tests/static-analysis/assert-methodNotExists.php
@@ -48,3 +48,18 @@ function allMethodNotExists(iterable $classOrObject, $method): iterable
 
     return $classOrObject;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object|null> $classOrObject
+ * @param mixed $method
+ *
+ * @return iterable<class-string|object|null>
+ */
+function allNullOrMethodNotExists(iterable $classOrObject, $method): iterable
+{
+    Assert::allNullOrMethodNotExists($classOrObject, $method);
+
+    return $classOrObject;
+}

--- a/tests/static-analysis/assert-minCount.php
+++ b/tests/static-analysis/assert-minCount.php
@@ -43,3 +43,16 @@ function allMinCount($array, $min)
 
     return $array;
 }
+
+/**
+ * @param iterable<Countable|array|null> $array
+ * @param int|float $min
+ *
+ * @return iterable<Countable|array|null>
+ */
+function allNullOrMinCount($array, $min)
+{
+    Assert::allNullOrMinCount($array, $min);
+
+    return $array;
+}

--- a/tests/static-analysis/assert-minLength.php
+++ b/tests/static-analysis/assert-minLength.php
@@ -42,3 +42,18 @@ function allMinLength(iterable $value, $min): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ * @param int|float $min
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrMinLength(iterable $value, $min): iterable
+{
+    Assert::allNullOrMinLength($value, $min);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-natural.php
+++ b/tests/static-analysis/assert-natural.php
@@ -48,3 +48,20 @@ function allNatural($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<positive-int|0|null>
+ *
+ * @psalm-suppress MixedInferredReturnType https://github.com/vimeo/psalm/issues/5052
+ * @psalm-suppress MixedReturnStatement https://github.com/vimeo/psalm/issues/5052
+ */
+function allNullOrNatural($value): iterable
+{
+    Assert::allNullOrNatural($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-notContains.php
+++ b/tests/static-analysis/assert-notContains.php
@@ -37,3 +37,17 @@ function allNotContains(iterable $value, string $subString): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrNotContains(iterable $value, string $subString): iterable
+{
+    Assert::allNullOrNotContains($value, $subString);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-notEmpty.php
+++ b/tests/static-analysis/assert-notEmpty.php
@@ -77,3 +77,17 @@ function allNotEmpty($value)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrNotEmpty($value)
+{
+    Assert::allNullOrNotEmpty($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-notEq.php
+++ b/tests/static-analysis/assert-notEq.php
@@ -42,3 +42,16 @@ function allNotEq($value, $expect)
 
     return $value;
 }
+
+/**
+ * @param mixed $value
+ * @param mixed $expect
+ *
+ * @return mixed
+ */
+function allNullOrNotEq($value, $expect)
+{
+    Assert::allNullOrNotEq($value, $expect);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-notFalse.php
+++ b/tests/static-analysis/assert-notFalse.php
@@ -55,3 +55,17 @@ function allNotFalse($value)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrNotFalse($value)
+{
+    Assert::allNullOrNotFalse($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-notInstanceOf.php
+++ b/tests/static-analysis/assert-notInstanceOf.php
@@ -49,3 +49,19 @@ function allNotInstanceOf($value, $class)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ * @psalm-template T of object
+ *
+ * @param mixed $value
+ * @param class-string<T> $class
+ *
+ * @return mixed
+ */
+function allNullOrNotInstanceOf($value, $class)
+{
+    Assert::allNullOrNotInstanceOf($value, $class);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-notRegex.php
+++ b/tests/static-analysis/assert-notRegex.php
@@ -37,3 +37,17 @@ function allNotRegex(iterable $value, string $pattern): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrNotRegex(iterable $value, string $pattern): iterable
+{
+    Assert::allNotRegex($value, $pattern);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-notSame.php
+++ b/tests/static-analysis/assert-notSame.php
@@ -48,3 +48,18 @@ function allNotSame($value, $expect)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ * @param mixed $expect
+ *
+ * @return mixed
+ */
+function allNullOrNotSame($value, $expect)
+{
+    Assert::allNullOrNotSame($value, $expect);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-notWhitespaceOnly.php
+++ b/tests/static-analysis/assert-notWhitespaceOnly.php
@@ -37,3 +37,17 @@ function allNotWhitespaceOnly(iterable $value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrNotWhitespaceOnly(iterable $value): iterable
+{
+    Assert::allNullOrNotWhitespaceOnly($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-numeric.php
+++ b/tests/static-analysis/assert-numeric.php
@@ -45,3 +45,17 @@ function allNumeric($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<numeric|null>
+ */
+function allNullOrNumeric($value): iterable
+{
+    Assert::allNullOrNumeric($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-object.php
+++ b/tests/static-analysis/assert-object.php
@@ -41,3 +41,17 @@ function allObject($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<object|null>
+ */
+function allNullOrObject($value): iterable
+{
+    Assert::allNullOrObject($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-oneOf.php
+++ b/tests/static-analysis/assert-oneOf.php
@@ -45,3 +45,17 @@ function allOneOf($value, array $values)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrOneOf($value, array $values)
+{
+    Assert::allNullOrOneOf($value, $values);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-positiveInteger.php
+++ b/tests/static-analysis/assert-positiveInteger.php
@@ -59,3 +59,17 @@ function allPositiveInteger($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<positive-int|null>
+ */
+function allNullOrPositiveInteger($value): iterable
+{
+    Assert::allPositiveInteger($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-propertyExists.php
+++ b/tests/static-analysis/assert-propertyExists.php
@@ -48,3 +48,18 @@ function allPropertyExists(iterable $classOrObject, $property): iterable
 
     return $classOrObject;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object|null> $classOrObject
+ * @param mixed $property
+ *
+ * @return iterable<class-string|object|null>
+ */
+function allNullOrPropertyExists(iterable $classOrObject, $property): iterable
+{
+    Assert::allPropertyExists($classOrObject, $property);
+
+    return $classOrObject;
+}

--- a/tests/static-analysis/assert-propertyNotExists.php
+++ b/tests/static-analysis/assert-propertyNotExists.php
@@ -48,3 +48,18 @@ function allPropertyNotExists(iterable $classOrObject, $property): iterable
 
     return $classOrObject;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object|null> $classOrObject
+ * @param mixed $property
+ *
+ * @return iterable<class-string|object|null>
+ */
+function allNullOrPropertyNotExists(iterable $classOrObject, $property): iterable
+{
+    Assert::allNullOrPropertyNotExists($classOrObject, $property);
+
+    return $classOrObject;
+}

--- a/tests/static-analysis/assert-range.php
+++ b/tests/static-analysis/assert-range.php
@@ -51,3 +51,19 @@ function allRange($value, $min, $max)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ * @param mixed $min
+ * @param mixed $max
+ *
+ * @return mixed
+ */
+function allNullOrRange($value, $min, $max)
+{
+    Assert::allNullOrRange($value, $min, $max);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-readable.php
+++ b/tests/static-analysis/assert-readable.php
@@ -29,3 +29,15 @@ function allReadable(iterable $value): iterable
 
     return $value;
 }
+
+/**
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrReadable(iterable $value): iterable
+{
+    Assert::allNullOrReadable($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-regex.php
+++ b/tests/static-analysis/assert-regex.php
@@ -37,3 +37,17 @@ function allRegex(iterable $value, string $pattern): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrRegex(iterable $value, string $pattern): iterable
+{
+    Assert::allRegex($value, $pattern);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-resource.php
+++ b/tests/static-analysis/assert-resource.php
@@ -48,3 +48,18 @@ function allResource($value, $type): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ * @param null|string $type
+ *
+ * @return iterable<resource|null>
+ */
+function allNullOrResource($value, $type): iterable
+{
+    Assert::allNullOrResource($value, $type);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-same.php
+++ b/tests/static-analysis/assert-same.php
@@ -48,3 +48,18 @@ function allSame($value, $expect)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ * @param mixed $expect
+ *
+ * @return mixed
+ */
+function allNullOrSame($value, $expect)
+{
+    Assert::allNullOrSame($value, $expect);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-scalar.php
+++ b/tests/static-analysis/assert-scalar.php
@@ -45,3 +45,17 @@ function allScalar($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<scalar|null>
+ */
+function allNullOrScalar($value): iterable
+{
+    Assert::allNullOrScalar($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-startsWith.php
+++ b/tests/static-analysis/assert-startsWith.php
@@ -37,3 +37,17 @@ function allStartsWith(iterable $value, string $prefix): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrStartsWith(iterable $value, string $prefix): iterable
+{
+    Assert::allNullOrStartsWith($value, $prefix);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-startsWithLetter.php
+++ b/tests/static-analysis/assert-startsWithLetter.php
@@ -45,3 +45,17 @@ function allStartsWithLetter($value, string $prefix)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrStartsWithLetter($value, string $prefix)
+{
+    Assert::allNullOrStartsWithLetter($value, $prefix);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-string.php
+++ b/tests/static-analysis/assert-string.php
@@ -41,3 +41,17 @@ function allString($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrString($value): iterable
+{
+    Assert::allNullOrString($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-stringNotEmpty.php
+++ b/tests/static-analysis/assert-stringNotEmpty.php
@@ -45,3 +45,17 @@ function allStringNotEmpty($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<non-empty-string|null>
+ */
+function allNullOrStringNotEmpty($value): iterable
+{
+    Assert::allNullOrStringNotEmpty($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-subclassOf.php
+++ b/tests/static-analysis/assert-subclassOf.php
@@ -46,3 +46,17 @@ function allSubclassOf($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<class-string<stdClass>|stdClass|null>
+ */
+function allNullOrSubclassOf($value): iterable
+{
+    Assert::allNullOrSubclassOf($value, stdClass::class);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-throws.php
+++ b/tests/static-analysis/assert-throws.php
@@ -38,3 +38,15 @@ function allThrows(iterable $value, $class): iterable
 
     return $value;
 }
+/**
+ * @param iterable<Closure|null> $value
+ * @param class-string<Throwable> $class
+ *
+ * @return iterable<Closure>
+ */
+function allNullOrThrows(iterable $value, $class): iterable
+{
+    Assert::allNullOrThrows($value, $class);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-true.php
+++ b/tests/static-analysis/assert-true.php
@@ -45,3 +45,17 @@ function allTrue($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<true|null>
+ */
+function allNullOrTrue($value): iterable
+{
+    Assert::allNullOrTrue($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-unicodeLetters.php
+++ b/tests/static-analysis/assert-unicodeLetters.php
@@ -45,3 +45,17 @@ function allUnicodeLetters($value)
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function allNullOrUnicodeLetters($value)
+{
+    Assert::allNullOrUnicodeLetters($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-uniqueValues.php
+++ b/tests/static-analysis/assert-uniqueValues.php
@@ -29,3 +29,15 @@ function allUniqueValues(iterable $values): iterable
 
     return $values;
 }
+
+/**
+ * @param iterable<array|null> $values
+ *
+ * @return iterable<array|null>
+ */
+function allNullOrUniqueValues(iterable $values): iterable
+{
+    Assert::allNullOrUniqueValues($values);
+
+    return $values;
+}

--- a/tests/static-analysis/assert-upper.php
+++ b/tests/static-analysis/assert-upper.php
@@ -37,3 +37,17 @@ function allUpper(iterable $value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrUpper(iterable $value): iterable
+{
+    Assert::allNullOrUpper($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-uuid.php
+++ b/tests/static-analysis/assert-uuid.php
@@ -37,3 +37,17 @@ function allUuid(iterable $value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrUuid(iterable $value): iterable
+{
+    Assert::allNullOrUuid($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-validArrayKey.php
+++ b/tests/static-analysis/assert-validArrayKey.php
@@ -45,3 +45,17 @@ function allValidArrayKey($value): iterable
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed $value
+ *
+ * @return iterable<array-key|null>
+ */
+function allNullOrValidArrayKey($value): iterable
+{
+    Assert::allNullOrValidArrayKey($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-writable.php
+++ b/tests/static-analysis/assert-writable.php
@@ -29,3 +29,15 @@ function allWritable(iterable $value): iterable
 
     return $value;
 }
+
+/**
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrWritable(iterable $value): iterable
+{
+    Assert::allNullOrWritable($value);
+
+    return $value;
+}


### PR DESCRIPTION
Hi @Nyholm 

I recently had the need of a `allNullOrScalar` method to check (and help my static analysis tool to understand) a variable is `array<bool|int|float|string|null>`.

To keep consistency I added all the `allNullOr` possible methods.