### PR TITLE
Fix lessThan test fails in a different time zone

### DIFF
--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -718,7 +718,7 @@ class AssertTest extends TestCase
             array('eq', array(new ArrayIterator(array()), new stdClass()), 'Expected a value equal to stdClass. Got: ArrayIterator'),
             array('eq', array(1, self::getResource()), 'Expected a value equal to resource. Got: 1'),
 
-            array('lessThan', array(new \DateTime('2020-01-01 00:00:00'), new \DateTime('1999-01-01 00:00:00')), 'Expected a value less than DateTime: "1999-01-01T00:00:00+00:00". Got: DateTime: "2020-01-01T00:00:00+00:00"'),
+            array('lessThan', array(new \DateTime('2020-01-01 00:00:00+00:00'), new \DateTime('1999-01-01 00:00:00+00:00')), 'Expected a value less than DateTime: "1999-01-01T00:00:00+00:00". Got: DateTime: "2020-01-01T00:00:00+00:00"'),
         );
     }
 


### PR DESCRIPTION
Hello,

I have a little issue with your library. I couldn't run all the tests successfully from the first time.

One of the tests from testConvertValuesToStrings fails with an error:
`Failed asserting that exception message 'Expected a value less than DateTime: "1999-01-01T00:00:00+03:00". Got: DateTime: "2020-01-01T00:00:00+03:00"' contains 'Expected a value less than DateTime: "1999-01-01T00:00:00+00:00". Got: DateTime: "2020-01-01T00:00:00+00:00"'.`

The problem is that the test data for `lessThan` method doesn’t take the time zone into account while it instantiates the DateTime values. In my case, the computer uses the time zone `+03.00` and that causes the test to fail. My proposition is to provide a default fixed time zone with a date/time string to the DateTime() constructor.
