### PR TITLE
Reduced dependency graph by removing `symfony/polyfill-ctype`, requiring `ext-ctype`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "symfony/polyfill-ctype": "^1.8"
+        "ext-ctype": "*"
     },
     "conflict": {
         "phpstan/phpstan": "<0.12.20",

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
     "name": "webmozart/assert",
     "description": "Assertions to validate method input/output with nice error messages.",
+    "license": "MIT",
     "keywords": [
         "assert",
         "check",
         "validate"
     ],
-    "license": "MIT",
     "authors": [
         {
             "name": "Bernhard Schussek",
@@ -17,17 +17,12 @@
         "php": "^7.2 || ^8.0",
         "ext-ctype": "*"
     },
-    "conflict": {
-        "phpstan/phpstan": "<0.12.20",
-        "vimeo/psalm": "<4.6.1 || 4.6.2"
-    },
     "require-dev": {
         "phpunit/phpunit": "^8.5.13"
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.10-dev"
-        }
+    "conflict": {
+        "phpstan/phpstan": "<0.12.20",
+        "vimeo/psalm": "<4.6.1 || 4.6.2"
     },
     "autoload": {
         "psr-4": {
@@ -38,6 +33,11 @@
         "psr-4": {
             "Webmozart\\Assert\\Tests\\": "tests/",
             "Webmozart\\Assert\\Bin\\": "bin/src"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.10-dev"
         }
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,6 +9,9 @@
     <projectFiles>
         <directory name="bin" />
         <directory name="tests/static-analysis" />
+        <ignoreFiles>
+            <directory name="ci"/>
+        </ignoreFiles>
     </projectFiles>
 
 </psalm>


### PR DESCRIPTION
The resaon this change is necessary is that `symfony/polyfill-ctype` is a **provider** of `ext-ctype`,
but it is not `ext-ctype`.

`ext-ctype` is the actual dependency being requested, and it is up to downstream consumers to decide
whether to install the extension, or polyfill it.

In addition to that, we want to test that this tool works with `ext-ctype`, not with the polyfill: the polyfill
is responsible (on its own) to guarantee parity with `ext-ctype`, while we have some fake confidence
(due to indirection) here.

With this change, we effectively revert `1.4.0`, and slim down the dependency graph by a bit for
hundreds of thousands of downstream projects.

Ref: https://github.com/webmozarts/assert/commit/18879ed87119d4d11d57eb76c2997200dd632ce1
Ref: https://github.com/webmozarts/assert/commit/18879ed87119d4d11d57eb76c2997200dd632ce1#commitcomment-70510654