### PR TITLE
Fix psalm assert

### DIFF
--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -690,7 +690,7 @@ trait Mixin
      * @psalm-pure
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $class
-     * @psalm-assert iterable<ExpectedType> $value
+     * @psalm-assert array<ExpectedType> $value
      *
      * @param mixed         $value
      * @param string|object $class


### PR DESCRIPTION
Dockblock `allIsInstanceOf` method replaces the type for Psalm.

Create class:

```php
$integrationEvent = KppExpertiseCreated::createFromBody([
    'attachments' => array_map(function (CaseAttachment $attachment): Attachment {
        return new Attachment(
            $attachment->getId(),
            $attachment->getName(),
            $this->urlGenerator->generate('files.read', ['id' => $attachment->getResourceId()]),
        );
    }, $case->getAttachments()),
]);

$this->dispatcher->dispatch([$integrationEvent]);
```

```php
public static function createFromBody(string $id, DateTimeImmutable $datetime, array $body): AmqpEvent
{
    Assert::allIsInstanceOf($body['attachments'], Attachment::class);
    $event->attachments = $body['attachments’];
    return $event;
}
```

Error:

`
ERROR: InvalidPropertyAssignmentValue - src/Integration/App/Listener/Estimation/Expertise/Event/KppExpertiseCreated.php:48:31 - $event->attachments with declared type 'array<array-key, App\Integration\App\Listener\Estimation\Expertise\Event\Attachment>' cannot be assigned type 'iterable<array-key|mixed, App\Integration\App\Listener\Estimation\Expertise\Event\Attachment>' (see https://psalm.dev/145)
        $event->attachments = $body['attachments'];
`

When using `@psalm-assert array<ExpectedType> $value`, the error disappears