### PR TITLE
Fix minor typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changelog
 
 ### Added
 
-* Added explicit (non magic) `allNullOr*` methods, with `@psalm-assert` annotations, for better Psalm support.
+* Added explicit (non-magic) `allNullOr*` methods, with `@psalm-assert` annotations, for better Psalm support.
 
 ### Changed
 
@@ -17,7 +17,7 @@ Changelog
 
 ### Removed
 
-* Removed `symfony/polyfill-ctype` as a dependency, and require `ext-cytpe` instead.
+* Removed `symfony/polyfill-ctype` as a dependency, and require `ext-ctype` instead.
   * You can still require the `symfony/polyfill-ctype` in your project if you need it, as it provides `ext-ctype`
 
 ## 1.10.0
@@ -51,7 +51,7 @@ Changelog
 ## Changed
 
 * the `all*` & `nullOr*` methods are now declared on an interface, instead of `@method` annotations.
-This interface is linked to the `Assert` class with a `@mixin` annotation. Most IDE's have supported this
+This interface is linked to the `Assert` class with a `@mixin` annotation. Most IDEs have supported this
 for a long time, and you should not lose any autocompletion capabilities. PHPStan has supported this since
 version `0.12.20`. This package is marked incompatible (with a composer conflict) with phpstan version prior to that.
 If you do not use PHPStan than this does not matter.

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Assert::allIsInstanceOf($employees, 'Acme\Employee');
 ### Nullable Assertions
 
 All of the above assertions can be prefixed with `nullOr*()` to run the
-assertion only if it the value is not `null`:
+assertion only if the value is not `null`:
 
 ```php
 Assert::nullOrString($middleName, 'The middle name must be a string or null. Got: %s');
@@ -243,7 +243,7 @@ Overriding the following methods in your assertion class allows you to change th
 * `protected static function valueToString($value)`
   * This method is used for error messages, to convert the value to a string value for displaying. You could use this for representing a value object with a `__toString` method for example.
 * `protected static function typeToString($value)`
-  * This method is used for error messages, to convert the a value to a string representing its type.
+  * This method is used for error messages, to convert a value to a string representing its type.
 * `protected static function strlen($value)`
   * This method is used to calculate string length for relevant methods, using the `mb_strlen` if available and useful.
 * `protected static function reportInvalidArgument($message)`

--- a/bin/src/MixinGenerator.php
+++ b/bin/src/MixinGenerator.php
@@ -104,7 +104,7 @@ PHP
         return \sprintf(
             <<<'PHP'
 /**
- * This trait provides nurllOr*, all* and allNullOr* variants of assertion base methods.
+ * This trait provides nullOr*, all* and allNullOr* variants of assertion base methods.
  * Do not use this trait directly: it will change, and is not designed for reuse.
  */
 trait Mixin

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -8,7 +8,7 @@ use Countable;
 use Throwable;
 
 /**
- * This trait provides nurllOr*, all* and allNullOr* variants of assertion base methods.
+ * This trait provides nullOr*, all* and allNullOr* variants of assertion base methods.
  * Do not use this trait directly: it will change, and is not designed for reuse.
  */
 trait Mixin


### PR DESCRIPTION
I noticed `ext-cytpe` typo, so let my IDE show me other typos.