### PR TITLE
Fix `implementsInterface()` PHPDoc

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1609,7 +1609,7 @@ class Assert
      *
      * @psalm-param class-string<ExpectedType> $interface
      *
-     * @psalm-assert class-string<ExpectedType> $value
+     * @psalm-assert class-string<ExpectedType>|ExpectedType $value
      *
      * @param mixed  $value
      * @param mixed  $interface

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -4167,7 +4167,7 @@ trait Mixin
      *
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $interface
-     * @psalm-assert class-string<ExpectedType>|null $value
+     * @psalm-assert class-string<ExpectedType>|ExpectedType|null $value
      *
      * @param mixed  $value
      * @param mixed  $interface
@@ -4187,7 +4187,7 @@ trait Mixin
      *
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $interface
-     * @psalm-assert iterable<class-string<ExpectedType>> $value
+     * @psalm-assert iterable<class-string<ExpectedType>|ExpectedType> $value
      *
      * @param mixed  $value
      * @param mixed  $interface
@@ -4211,7 +4211,7 @@ trait Mixin
      *
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $interface
-     * @psalm-assert iterable<class-string<ExpectedType>|null> $value
+     * @psalm-assert iterable<class-string<ExpectedType>|ExpectedType|null> $value
      *
      * @param mixed  $value
      * @param mixed  $interface

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -14,6 +14,7 @@ namespace Webmozart\Assert\Tests;
 use ArrayIterator;
 use ArrayObject;
 use DateTime;
+use DateTimeImmutable;
 use Error;
 use Exception;
 use LogicException;
@@ -447,6 +448,10 @@ class AssertTest extends TestCase
             array('interfaceExists', array(__CLASS__), false),
             array('implementsInterface', array('ArrayIterator', 'Traversable'), true),
             array('implementsInterface', array(__CLASS__, 'Traversable'), false),
+            array('implementsInterface', array(new DateTimeImmutable(), 'DateTimeInterface'), true),
+            array('implementsInterface', array(new DateTimeImmutable(), 'Traversable'), false),
+            array('implementsInterface', array(new ArrayIterator(array()), 'DateTimeInterface'), false),
+            array('implementsInterface', array(new ArrayIterator(array()), 'Traversable'), true),
             array('propertyExists', array((object) array('property' => 0), 'property'), true),
             array('propertyExists', array((object) array('property' => null), 'property'), true),
             array('propertyExists', array((object) array('property' => null), 'foo'), false),

--- a/tests/static-analysis/assert-implementsInterface.php
+++ b/tests/static-analysis/assert-implementsInterface.php
@@ -10,9 +10,9 @@ use Webmozart\Assert\Assert;
  *
  * @param mixed $value
  *
- * @return class-string<Serializable>
+ * @return Serializable|class-string<Serializable>
  */
-function implementsInterface($value): string
+function implementsInterface($value)
 {
     Assert::implementsInterface($value, Serializable::class);
 
@@ -24,9 +24,9 @@ function implementsInterface($value): string
  *
  * @param mixed $value
  *
- * @return null|class-string<Serializable>
+ * @return Serializable|class-string<Serializable>|null
  */
-function nullOrImplementsInterface($value): ?string
+function nullOrImplementsInterface($value)
 {
     Assert::nullOrImplementsInterface($value, Serializable::class);
 
@@ -38,7 +38,7 @@ function nullOrImplementsInterface($value): ?string
  *
  * @param mixed $value
  *
- * @return iterable<class-string<Serializable>>
+ * @return iterable<mixed, Serializable|class-string<Serializable>>
  */
 function allImplementsInterface($value): iterable
 {
@@ -52,7 +52,7 @@ function allImplementsInterface($value): iterable
  *
  * @param mixed $value
  *
- * @return iterable<class-string<Serializable>|null>
+ * @return iterable<mixed, Serializable|class-string<Serializable>|null>
  */
 function allNullOrImplementsInterface($value): iterable
 {


### PR DESCRIPTION
`class_implements` accepts either an object or a class-string, but the PHPDoc for the assert function is wrong and limits its functionality to a class-string only. I'm not entirely sure if this was on purpose, the README just mentions "Check that a class implements an interface", but it would work with either an instance of a class or a class-string and the assertion is under the "object" category.

See also https://phpstan.org/r/c72bb8af-4f27-462b-85f6-e2d3b81b9786 where this is tested in PHPStan (which just got support for PHPDoc-based type narrowing, this is not released yet)

Refs: https://github.com/phpstan/phpstan-webmozart-assert/pull/144#issuecomment-1268122389

I could not cleanly run psalm locally without unrelated errors, let's see what happens on CI 🤞