### PR TITLE
Optimize isList

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1881,10 +1881,11 @@ class Assert
                     $message ?: 'Expected list - non-associative array.'
                 );
             }
+
             return;
         }
 
-        if ([] === $array) {
+        if (array() === $array) {
             return;
         }
 

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1875,17 +1875,24 @@ class Assert
             );
         }
 
-        if ($array === \array_values($array)) {
-            return;
-        }
-
-        $nextKey = -1;
-        foreach ($array as $k => $v) {
-            if ($k !== ++$nextKey) {
+        if (\function_exists('array_is_list')) {
+            if (!\array_is_list($array)) {
                 static::reportInvalidArgument(
                     $message ?: 'Expected list - non-associative array.'
                 );
             }
+            return;
+        }
+
+        if ([] === $array) {
+            return;
+        }
+
+        $keys = array_keys($array);
+        if (array_keys($keys) !== $keys) {
+            static::reportInvalidArgument(
+                $message ?: 'Expected list - non-associative array.'
+            );
         }
     }
 


### PR DESCRIPTION
This is a follow up to the discussion from #247.
During normal usage, I noticed this function is very inefficient. It doesn't use the built-in function `array_is_list` and the polyfil is very inefficient for most cases. Yes, the current implementation is very efficient for true lists, but has very bad performance with any other list, e.g. the one from the previous PR. 

The current implementation would benefit from a very simple optimization: `foreach (array_keys($array) as $k) {` but no sense in doing this if we can achieve an overall better performance with just `array_keys`. 

The current implementation builds a new array in memory. This is super efficient if the array was built like this `range(1, 1000)`. But if the array is large and contains other arrays or objects then building a copy of it is very bad. So we need to get rid of `array_values()`. This also solves the issue from previous PR because we are no longer comparing the values. 

This is the most efficient and the most correct implementation I could find. 

