### PR TITLE
Update ci.yaml replacing GitHub Actions V2 (Deprecated) for V3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             -   name: "Checkout"
-                uses: "actions/checkout@v2.3.4"
+                uses: "actions/checkout@v3"
 
             -   name: "Install PHP"
                 uses: "shivammathur/setup-php@2.9.0"
@@ -47,7 +47,7 @@ jobs:
 
         steps:
             -   name: "Checkout"
-                uses: "actions/checkout@v2.3.4"
+                uses: "actions/checkout@v3"
 
             -   name: "Install PHP"
                 uses: "shivammathur/setup-php@2.9.0"
@@ -69,7 +69,7 @@ jobs:
 
         steps:
           - name: "Checkout code"
-            uses: "actions/checkout@v2"
+            uses: "actions/checkout@v3"
 
           - name: "Roave BC Check"
             uses: "docker://nyholm/roave-bc-check-ga"
@@ -90,7 +90,7 @@ jobs:
 
         steps:
             -   name: "Checkout"
-                uses: "actions/checkout@v2.3.4"
+                uses: "actions/checkout@v3"
 
             -   name: "Install PHP"
                 uses: "shivammathur/setup-php@2.9.0"
@@ -117,7 +117,7 @@ jobs:
 
         steps:
             -   name: "Checkout"
-                uses: "actions/checkout@v2.3.4"
+                uses: "actions/checkout@v3"
 
             -   name: "Install PHP"
                 uses: "shivammathur/setup-php@2.9.0"


### PR DESCRIPTION
This updates to GitHub Action V3 as the V2 is deprecated. This resolves some of the warnings shown at the bottom of https://github.com/webmozarts/assert/actions/runs/3333136431 (and other Actions runs)

## Additional context
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/