### PR TITLE
Separate file/directory/exists assertions

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1467,11 +1467,9 @@ class Assert
      */
     public static function fileExists($value, $message = '')
     {
-        static::string($value);
-
         if (!\file_exists($value)) {
             static::reportInvalidArgument(\sprintf(
-                $message ?: 'The file %s does not exist.',
+                $message ?: 'The path %s does not exist.',
                 static::valueToString($value)
             ));
         }
@@ -1485,8 +1483,6 @@ class Assert
      */
     public static function file($value, $message = '')
     {
-        static::fileExists($value, $message);
-
         if (!\is_file($value)) {
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'The path %s is not a file.',
@@ -1503,11 +1499,9 @@ class Assert
      */
     public static function directory($value, $message = '')
     {
-        static::fileExists($value, $message);
-
         if (!\is_dir($value)) {
             static::reportInvalidArgument(\sprintf(
-                $message ?: 'The path %s is no directory.',
+                $message ?: 'The path %s is not a directory.',
                 static::valueToString($value)
             ));
         }


### PR DESCRIPTION
There is no need to use `file_exists` before using `is_file` and `is_dir`, this makes for confusing errors. For instance, if you call `Assert::directory('invalid/path')` then the reported error will be:

```
The file "invalid/path" does not exist.
```

Additionally, the messages for these assertions were either technically or grammatically incorrect.