### PR TITLE
Fix error on `resource` assertion if message has a second placeholder

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -266,7 +266,8 @@ class Assert
         if (!\is_resource($value)) {
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a resource. Got: %s',
-                static::typeToString($value)
+                static::typeToString($value),
+                $type // User supplied message might include the second placeholder.
             ));
         }
 

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -820,6 +820,14 @@ class AssertTest extends TestCase
 
         call_user_func_array(array('Webmozart\Assert\Assert', 'isAOf'), $args);
     }
+
+    public function testResourceOfTypeCustomMessage(): void
+    {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('I want a resource of type curl. Got: NULL');
+
+        Assert::resource(null, 'curl', 'I want a resource of type %2$s. Got: %s');
+    }
 }
 
 /**


### PR DESCRIPTION
Prior to this change code such as
`Assert::resource(null, 'stream', 'Got: %s, type: %s')` would fail as
the second placeholder was only passed into `sprintf()` if the value
supplied is a resource.

Test I've added without the code change fails with:

```
1) Webmozart\Assert\Tests\AssertTest::testResourceOfTypeCustomMessage
Failed asserting that exception of type "ArgumentCountError" matches expected exception "\InvalidArgumentException". Message was: "3 arguments are required, 2 given" at
<snip>/src/Assert.php:255
<snip>/tests/AssertTest.php:827
```
