### PR TITLE
Add `@psalm-pure` to the `typeToString` method

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -2102,6 +2102,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param mixed $value
      *
      * @return string


### PR DESCRIPTION
When extending the `Assert` class it can be difficult to keep custom methods pure, especially when opting for the use of the `Assert::typeToString` method. This results in the following Psalm error at the call to the `typetoString` method:

```
ImpureMethodCall: Cannot call an impure method from a pure context
```

Currently there are two options to avoid the error:

- Don't mark your custom method pure.
- Suppress the `ImpureMethodCall` psalm error for your custom pure method.

Ideally you neither pick one of those options.

This PR fixes the error for good error by marking the `Assert::typeToString` method as [`@psalm-pure`](https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-pure).