### PR TITLE
Add validRegexPattern assertions

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1230,6 +1230,26 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string $value
+     * @param string $message
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function validRegexPattern($value, $message = 'The value %s must be a valid regex pattern.')
+    {
+        static::string($value);
+
+        if (@\preg_match($value, '') === false) {
+            static::reportInvalidArgument(\sprintf(
+                $message,
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
      * @param mixed  $value
      * @param string $message
      *

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -5207,4 +5207,57 @@ trait Mixin
             null === $entry || static::throws($entry, $class, $message);
         }
     }
+
+    /**
+     * @psalm-pure
+     *
+     * @param string|null $value
+     * @param string      $message
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function nullOrValidRegexPattern($value, $message = '')
+    {
+        null === $value || static::validRegexPattern($value, $message);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param iterable<string> $value
+     * @param string           $message
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function allValidRegexPattern($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::validRegexPattern($entry, $message);
+        }
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param iterable<string|null> $value
+     * @param string                $message
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function allNullOrValidRegexPattern($value, $message = '')
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            null === $entry || static::validRegexPattern($entry, $message);
+        }
+    }
 }

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -595,6 +595,12 @@ class AssertTest extends TestCase
             array('uniqueValues', array(array('qwerty', 'qwerty')), false),
             array('uniqueValues', array(array('asdfg', 'qwerty')), true),
             array('uniqueValues', array(array(123, '123')), false),
+            array('validRegexPattern', array('/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/'), true),
+            array('validRegexPattern', array('/^\(\d{3}\) \d{3}-\d{4}$/'), true),
+            array('validRegexPattern', array('/^https?:\/\/[^\s/$.?#].[^\s]*$/i'), true),
+            array('validRegexPattern', array('/^(abc/'), false), // Unclosed parenthesis
+            array('validRegexPattern', array('/[a-z-]/'), false), // Improper character class
+            array('validRegexPattern', array('/(?:abc)\1/'), false), // Backreference to non-capturing group
         );
     }
 


### PR DESCRIPTION
# Why?

1. PHP functions working with regex (`preg_match`, `preg_replace`, etc.) work in _legacy_ way — they just return `false` instead of throwing exception.
2. The way to check if the string is regex is quite hacky, so, would be great to hide the check implementation somewhere.

# References

1. https://stackoverflow.com/a/8825096/3578207