### PR TITLE
Add ext-filter to dependency list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "ext-ctype": "*"
+        "ext-ctype": "*",
+        "ext-filter": "*"
     },
     "suggest": {
         "ext-simplexml": ""


### PR DESCRIPTION
There seem to be usages of `ext-filter`, but it is not listed in the dependency list.

Some examples:
- https://github.com/webmozarts/assert/blob/f23349fa116314ad78d0cfb51228c43793860857/src/Assert.php#L727
- https://github.com/webmozarts/assert/blob/f23349fa116314ad78d0cfb51228c43793860857/src/Assert.php#L743
- https://github.com/webmozarts/assert/blob/f23349fa116314ad78d0cfb51228c43793860857/src/Assert.php#L775